### PR TITLE
fix(demo): pin CogStream tile-record shape to whitebox-wasm 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,21 +66,26 @@ const range = (a, b) =>
 
 // 1. Open the COG header with whitebox-wasm's streamer.
 const stream = new CogStream(await range(0, 65535));
-const levels = JSON.parse(stream.levels_json()); // [{width,height}, ...] finest first
+// levels: [{level,width,height,tile_width,tile_height,tiles_x,tiles_y,bands,
+//           bits_per_sample,sample_format,compression}, ...] finest first
+const levels = JSON.parse(stream.levels_json());
 
-// 2. Build the tiler from the COG metadata.
+// 2. Build the tiler from the COG metadata. CogStream's epsg/nodata getters are
+//    Option-typed: a number or `undefined` (not NaN), so pass them straight through.
 const tiler = new CogTiler(
-  Float64Array.from(stream.geo_transform()),
+  Float64Array.from(stream.geo_transform()), // [x0, px_w, rot, y0, rot, px_h]
   levels[0].width,
   levels[0].height,
   stream.epsg, // must be 3857 in v1
-  Number.isNaN(stream.nodata) ? undefined : stream.nodata,
+  stream.nodata, // undefined => no nodata
   JSON.stringify(levels),
 );
 
 // 3. Per XYZ tile: window -> fetch+decode -> render.
 const win = tiler.pixel_window_for_tile(z, x, y);
-// (use stream.tiles_for_window / decode_tile_f64 to assemble a w*h Float64Array)
+// tiles_for_window returns [{col,row,offset,length}]; the tile's pixel origin is
+// (col*tile_width, row*tile_height) and decode_tile_f64 is pixel-interleaved.
+// See demo/index.html `blit()` for the full window-assembly loop.
 const rgba = tiler.render(window, win.w, win.h, 0, 3000, "viridis", true);
 ```
 
@@ -96,7 +101,8 @@ A runnable MapLibre example (custom `cog://` protocol) is in
 - `width`/`height` - full-resolution pixel dimensions
 - `epsg` - source CRS; must be `3857` in v1
 - `nodata` - optional nodata value (`undefined`/`NaN` = none)
-- `levels_json` - JSON array of `{width,height}`, finest level first
+- `levels_json` - JSON array of level descriptors, finest level first; only
+  `width`/`height` are read (extra `whitebox-wasm` fields are ignored)
 
 Properties: `epsg`, `num_levels`.
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -63,7 +63,7 @@
       // The decode engine (pure-Rust COG codecs + remote range reads).
       import initWhitebox, {
         CogStream,
-      } from "https://esm.sh/whitebox-wasm";
+      } from "https://esm.sh/whitebox-wasm@0.4.0";
       // The tiling brain (this crate).
       import initTiler, { CogTiler } from "../crates/cog-tiler-wasm/pkg/cog_tiler_wasm.js";
 
@@ -105,6 +105,9 @@
         // levels: [{level,width,height,tile_width,tile_height,tiles_x,tiles_y,
         //           bands,bits_per_sample,sample_format,compression}, ...]
         const levels = JSON.parse(stream.levels_json());
+        if (!Array.isArray(levels) || levels.length === 0) {
+          throw new Error("levels_json() returned no levels");
+        }
         // CogStream getters are Option -> a number or `undefined` (not NaN).
         const tiler = new CogTiler(
           Float64Array.from(gt),

--- a/demo/index.html
+++ b/demo/index.html
@@ -97,24 +97,24 @@
           .then((r) => r.arrayBuffer())
           .then((b) => new Uint8Array(b));
 
-      // Build a {stream, tiler} pair for a COG URL.
+      // Build a {stream, tiler, levels} bundle for a COG URL.
       async function openCog(url) {
         const range = rangeFetcher(url);
         const stream = new CogStream(await range(0, 65535)); // header only
-        const gt = stream.geo_transform();
-        const levels = JSON.parse(stream.levels_json()); // [{width,height},...]
-        const epsg = stream.epsg;
-        const nodata = stream.nodata; // NaN if none
-        // CogTiler wants full-res width/height = level 0 dims.
+        const gt = stream.geo_transform(); // [x0, px_w, rot, y0, rot, px_h]
+        // levels: [{level,width,height,tile_width,tile_height,tiles_x,tiles_y,
+        //           bands,bits_per_sample,sample_format,compression}, ...]
+        const levels = JSON.parse(stream.levels_json());
+        // CogStream getters are Option -> a number or `undefined` (not NaN).
         const tiler = new CogTiler(
           Float64Array.from(gt),
           levels[0].width,
           levels[0].height,
-          epsg,
-          Number.isNaN(nodata) ? undefined : nodata,
+          stream.epsg, // must be 3857 in v1
+          stream.nodata, // undefined => no nodata
           JSON.stringify(levels),
         );
-        return { stream, tiler, range };
+        return { stream, tiler, range, levels };
       }
 
       let current = null;
@@ -122,7 +122,7 @@
       // MapLibre custom protocol: cog://{z}/{x}/{y}
       maplibregl.addProtocol("cog", async (params) => {
         if (!current) return { data: new Uint8Array() };
-        const { stream, tiler, range } = current;
+        const { stream, tiler, range, levels } = current;
         const m = params.url.match(/cog:\/\/(\d+)\/(\d+)\/(\d+)/);
         const [z, x, y] = m.slice(1).map(Number);
 
@@ -131,6 +131,7 @@
 
         // Ask CogStream which COG tiles cover the window, fetch + decode them,
         // and assemble a row-major f64 window.
+        const lv = levels[win.level];
         const tiles = JSON.parse(
           stream.tiles_for_window(win.level, win.x, win.y, win.w, win.h),
         );
@@ -138,7 +139,7 @@
         for (const t of tiles) {
           const bytes = await range(t.offset, t.offset + t.length - 1);
           const px = stream.decode_tile_f64(win.level, bytes); // tile-sized f64
-          blit(px, t, win, window); // place tile into the window (see helper)
+          blit(px, t, win, lv, window); // place tile into the window
         }
 
         const min = +document.getElementById("min").value;
@@ -170,21 +171,26 @@
 
       // --- small helpers --------------------------------------------------
 
-      // Place a decoded COG tile into the assembled window buffer. `t` carries
-      // the tile's pixel origin/size within the level (fields returned by
-      // CogStream.tiles_for_window); adjust field names to your CogStream build.
-      function blit(tilePx, t, win, out) {
-        const tw = t.width ?? t.tile_width;
-        const th = t.height ?? t.tile_height;
-        const tx0 = (t.x ?? t.col_off) - win.x;
-        const ty0 = (t.y ?? t.row_off) - win.y;
+      // Place a decoded COG tile into the assembled window buffer.
+      // CogStream.tiles_for_window records are { col, row, offset, length } - the
+      // tile's pixel origin in the level is (col*tile_width, row*tile_height),
+      // and decode_tile_f64 returns a full tile_width*tile_height*bands buffer,
+      // pixel-interleaved (stride by `bands` for band 0). Edge tiles come back
+      // full-size; the bounds checks clip them. (Shapes pinned against a real
+      // EPSG:3857 COG, whitebox-wasm 0.4.0.)
+      function blit(tilePx, t, win, lv, out) {
+        const tw = lv.tile_width;
+        const th = lv.tile_height;
+        const bands = lv.bands;
+        const tx0 = t.col * tw;
+        const ty0 = t.row * th;
         for (let ry = 0; ry < th; ry++) {
-          const oy = ty0 + ry;
+          const oy = ty0 + ry - win.y;
           if (oy < 0 || oy >= win.h) continue;
           for (let rx = 0; rx < tw; rx++) {
-            const ox = tx0 + rx;
+            const ox = tx0 + rx - win.x;
             if (ox < 0 || ox >= win.w) continue;
-            out[oy * win.w + ox] = tilePx[ry * tw + rx];
+            out[oy * win.w + ox] = tilePx[(ry * tw + rx) * bands]; // band 0
           }
         }
       }


### PR DESCRIPTION
## What

Pins the `whitebox-wasm` `CogStream` integration in the demo to its **real** API shape, verified empirically against a real EPSG:3857 COG (not guesses).

The original scaffold's `blit()` guessed tile-record field names (`t.x`, `t.width`, `t.col_off`, …). I read the authoritative shapes from the `whitebox-wasm` source and confirmed them by driving the full `CogStream` → `CogTiler` pipeline in a browser against a generated COG with known per-column pixel values.

## Pinned shapes (whitebox-wasm 0.4.0)

- `tiles_for_window(level,x,y,w,h)` → `[{col,row,offset,length}]` — **no per-tile pixel origin/size**; derive origin as `(col*tile_width, row*tile_height)`.
- `decode_tile_f64(level,bytes)` → length `tile_width*tile_height*bands`, **pixel-interleaved** (stride by `bands`), edge tiles full-size.
- `levels_json()` → entries with `tile_width`/`tile_height`/`bands` (+ more); `CogTiler` reads `width`/`height`, ignores extras.
- `geo_transform()` → `[x0, px_w, rot, y0, rot, px_h]` (GDAL order).
- `epsg`/`nodata` getters are `Option` → `number | undefined` (not `NaN`).

## Changes

- Rewrote demo `blit()` and `openCog()` to use the pinned shapes.
- Updated README usage/API to match.

## Verification

Generated a 768×768 EPSG:3857 COG (256px tiles, overviews [2,4], `value[r,c]=c`), served with HTTP Range + CORS, and ran the real `whitebox-wasm` + `cog-tiler-wasm` pipeline in Chromium:

- tile-record keys observed: `[col,length,offset,row]` ✓
- `decode_tile_f64` length 65536 = 256·256·1; sampled values matched known columns ✓
- assembled z14 window (spanning 4 tiles): **60,025/60,025 pixels matched known per-column values, 0 mismatches, 0 NaN** ✓
- overview selection: L1 at z12, L0 at z13–14 ✓

All test artifacts removed; no build output committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the README JavaScript example to use the full `levels_json()` output when creating `CogTiler`.
  * Updated `CogTiler` docs to describe `levels_json` as rich level descriptors (finest-first) and clarify which fields are consumed.
* **Demo**
  * Improved the demo’s COG loading flow to carry level metadata through tile assembly.
  * Updated the tile rendering pipeline to select the active level per window and assemble output using that level’s tile sizing and band layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->