### PR TITLE
fix(demo): import MapLibre from esm.sh so the map initializes

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -58,7 +58,7 @@
     <div id="map"></div>
 
     <script type="module">
-      import maplibregl from "https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js?module";
+      import maplibregl from "https://esm.sh/maplibre-gl@5.24.0";
 
       // The decode engine (pure-Rust COG codecs + remote range reads).
       import initWhitebox, {


### PR DESCRIPTION
## Bug

End-to-end testing the demo against a real EPSG:3857 COG DEM revealed the map never loads:

```
The requested module 'https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.js?module'
does not provide an export named 'default'
```

unpkg's `?module` serves the UMD bundle, which has no ESM default export, so `import maplibregl from …` throws and the demo is broken at load.

## Fix

Import MapLibre from `https://esm.sh/maplibre-gl@5.24.0` (consistent with the existing `whitebox-wasm` esm.sh import), which provides a proper default export.

## Verification (real end-to-end run)

Served the committed demo + the built `cog-tiler-wasm` pkg + a real 6 MB EPSG:3857 COG DEM (2880×1773, overviews [2,4]) over HTTP Range + CORS, and drove it in Chromium:

- with unpkg: 1 console error, no map canvas (reproduced the bug)
- with esm.sh: **0 errors, map canvas initializes**, status reports `EPSG:3857, 3 levels`, and the terrain-colored DEM renders correctly georeferenced over Oregon via the `cog://` protocol (whitebox-wasm decode → CogTiler window+render → MapLibre raster layer).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MapLibre GL module import source in the demo

<!-- end of auto-generated comment: release notes by coderabbit.ai -->