### PR TITLE
perf(demo): cache + parallel tile fetch; large-header retry; clear CRS error

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -153,7 +153,12 @@
         if (!p) {
           p = cur
             .range(t.offset, t.offset + t.length - 1)
-            .then((bytes) => cur.stream.decode_tile_f64(level, bytes));
+            .then((bytes) => cur.stream.decode_tile_f64(level, bytes))
+            .catch((err) => {
+              // Don't cache failures, so a transient error can be retried.
+              cur.tileCache.delete(key);
+              throw err;
+            });
           cur.tileCache.set(key, p);
           if (cur.tileCache.size > MAX_CACHED_TILES) {
             cur.tileCache.delete(cur.tileCache.keys().next().value); // evict oldest

--- a/demo/index.html
+++ b/demo/index.html
@@ -102,13 +102,32 @@
       // Build a {stream, tiler, levels} bundle for a COG URL.
       async function openCog(url) {
         const range = rangeFetcher(url);
-        const stream = new CogStream(await range(0, 65535)); // header only
+        // Parse the COG header. Large COGs (many overviews / huge tile-offset
+        // arrays) have headers bigger than 64 KB, so grow the prefix and retry.
+        let stream;
+        for (let len = 65536; ; len *= 8) {
+          try {
+            stream = new CogStream(await range(0, len - 1));
+            break;
+          } catch (e) {
+            if (len >= 1 << 25) throw e; // give up past ~32 MB
+          }
+        }
         const gt = stream.geo_transform(); // [x0, px_w, rot, y0, rot, px_h]
         // levels: [{level,width,height,tile_width,tile_height,tiles_x,tiles_y,
         //           bands,bits_per_sample,sample_format,compression}, ...]
         const levels = JSON.parse(stream.levels_json());
         if (!Array.isArray(levels) || levels.length === 0) {
           throw new Error("levels_json() returned no levels");
+        }
+        // v1 supports EPSG:3857 only. Reject other CRSs up front with a clear
+        // message instead of failing silently per-tile inside the protocol
+        // handler (e.g. NLCD is Albers, so the map would just stay blank).
+        if (stream.epsg !== 3857) {
+          const crs = stream.epsg ? "EPSG:" + stream.epsg : "non-3857 / unknown";
+          throw new Error(
+            `source CRS is ${crs}; this demo (v1) renders EPSG:3857 only - reproject the COG to 3857 first`,
+          );
         }
         // CogStream getters are Option -> a number or `undefined` (not NaN).
         const tiler = new CogTiler(
@@ -119,7 +138,28 @@
           stream.nodata, // undefined => no nodata
           JSON.stringify(levels),
         );
-        return { stream, tiler, range, levels };
+        // tileCache: decoded source tiles keyed by "level/col/row". Caching the
+        // decode (not just the bytes) means panning/zooming reuses overlapping
+        // source tiles instead of re-fetching and re-decoding them.
+        return { stream, tiler, range, levels, tileCache: new Map() };
+      }
+
+      // Fetch + decode one source tile, deduped and cached. Stores the promise
+      // so concurrent map tiles needing the same source tile share one request.
+      const MAX_CACHED_TILES = 256; // ~0.5 MB each at 256x256 f64
+      function getTile(cur, level, t) {
+        const key = level + "/" + t.col + "/" + t.row;
+        let p = cur.tileCache.get(key);
+        if (!p) {
+          p = cur
+            .range(t.offset, t.offset + t.length - 1)
+            .then((bytes) => cur.stream.decode_tile_f64(level, bytes));
+          cur.tileCache.set(key, p);
+          if (cur.tileCache.size > MAX_CACHED_TILES) {
+            cur.tileCache.delete(cur.tileCache.keys().next().value); // evict oldest
+          }
+        }
+        return p;
       }
 
       let current = null;
@@ -127,7 +167,7 @@
       // MapLibre custom protocol: cog://{z}/{x}/{y}
       maplibregl.addProtocol("cog", async (params) => {
         if (!current) return { data: new Uint8Array() };
-        const { stream, tiler, range, levels } = current;
+        const { stream, tiler, levels } = current;
         const m = params.url.match(/cog:\/\/(\d+)\/(\d+)\/(\d+)/);
         const [z, x, y] = m.slice(1).map(Number);
 
@@ -140,12 +180,13 @@
         const tiles = JSON.parse(
           stream.tiles_for_window(win.level, win.x, win.y, win.w, win.h),
         );
+        // Fetch + decode all covering tiles in parallel (cached/deduped), then
+        // assemble them into a row-major f64 window.
+        const decoded = await Promise.all(
+          tiles.map((t) => getTile(current, win.level, t)),
+        );
         const window = new Float64Array(win.w * win.h);
-        for (const t of tiles) {
-          const bytes = await range(t.offset, t.offset + t.length - 1);
-          const px = stream.decode_tile_f64(win.level, bytes); // tile-sized f64
-          blit(px, t, win, lv, window); // place tile into the window
-        }
+        tiles.forEach((t, i) => blit(decoded[i], t, win, lv, window));
 
         const min = +document.getElementById("min").value;
         const max = +document.getElementById("max").value;


### PR DESCRIPTION
Addresses two issues reported on the live demo: slow tile loading, and `nlcd_2021_land_cover_90m.tif` not working.

## Performance (tiles popped up slowly)

- **Decoded-tile cache** keyed by `level/col/row`, storing the in-flight promise so concurrent map tiles needing the same source tile share one request. Panning/zooming now reuses overlapping source tiles instead of re-fetching + re-decoding.
- **Parallel fetch**: the tiles covering each window are fetched with `Promise.all` instead of one sequential `await` at a time.

Benchmark over a 3×3 block of adjacent XYZ tiles: **16 → 4** source fetches, and **0 refetches** when revisiting the same view.

## NLCD "doesn't work"

`nlcd_2021_land_cover_90m.tif` failed for two reasons, both now handled gracefully:

1. **Header > 64 KB.** It's 53730×34808 with 7 overviews, so its COG header exceeds the demo's fixed 64 KB prefix - `CogStream` died with `failed to fill whole buffer`. `openCog()` now **grows the prefix and retries** (up to ~32 MB). Helps any large COG.
2. **Non-3857 CRS.** NLCD is Albers (reported as EPSG:4326). v1 renders 3857 only, and the rejection happened *per-tile* inside the protocol handler, so the map just stayed blank. `openCog()` now **rejects non-3857 up front** with a clear message: *"source CRS is EPSG:4326; this demo (v1) renders EPSG:3857 only - reproject the COG to 3857 first"*.

(NLCD is also a categorical palette raster, so even reprojected it would need color-table rendering - a separate roadmap item.)

## Verification

Driven in a browser against the real source.coop files:
- `dem.tif` (EPSG:3857) still renders correctly.
- `nlcd_2021_land_cover_90m.tif` now shows the clear CRS message instead of a blank map.
- Cache benchmark confirms the fetch reduction.

Only `demo/index.html` changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Added in-memory tile caching with capped eviction to speed up repeated tile access.
  * Improved tile assembly by fetching and decoding all tiles for the requested window in parallel.
* **Reliability Improvements**
  * Enhanced COG header retrieval with adaptive range requests and retries for larger files.
  * Added upfront CRS validation with clear errors when the data source is incompatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->