### PR TITLE
feat: warp projected COGs + paletted rendering, as a reusable cog-tiler.js module

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,11 +31,12 @@ jobs:
           wasm-pack build crates/cog-tiler-wasm --release --target web \
             --out-dir "$GITHUB_WORKSPACE/site"
           cp demo/index.html site/index.html
+          cp demo/cog-tiler.js site/cog-tiler.js
           cp examples/sample-3857-cog.tif site/sample-3857-cog.tif
           rm -f site/.gitignore
-          # Cache-bust the loader + wasm together so returning visitors never
-          # pair a freshly built module with a stale cached glue file.
-          sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html
+          # Cache-bust the loader + module + wasm together so returning visitors
+          # never pair a freshly built module with a stale cached glue file.
+          sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html site/cog-tiler.js
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/README.md
+++ b/README.md
@@ -72,42 +72,59 @@ python3 -m http.server -d demo 8000   # then open http://localhost:8000/
 The published [GitHub Pages demo](https://opengeos.github.io/cog-tiler-wasm/) is
 built the same way by `.github/workflows/pages.yml`.
 
-## Usage
+## Usage (reusable module)
+
+[`cog-tiler.js`](demo/cog-tiler.js) is the downstream-facing module. It wraps the
+wasm tiler + `whitebox-wasm` and handles EPSG:3857 sources, on-the-fly **warping**
+of any projected/4326 COG to Web Mercator, and **paletted (categorical)**
+rendering - so apps import it instead of copying the demo. It must sit next to the
+built wasm package (`cog_tiler_wasm.js` + `_bg.wasm`).
+
+Peer dependencies (provide via your bundler, or an import map for a no-build page):
+`whitebox-wasm`, `proj4`, `geotiff`, `geotiff-geokeys-to-proj4`.
 
 ```js
-import initTiler, { CogTiler } from "cog-tiler-wasm";
-import initWhitebox, { CogStream } from "whitebox-wasm";
-await Promise.all([initTiler(), initWhitebox()]);
+import maplibregl from "maplibre-gl";
+import { init, openCog, registerCogProtocol } from "./cog-tiler.js";
 
-const range = (a, b) =>
-  fetch(url, { headers: { Range: `bytes=${a}-${b}` } })
-    .then((r) => r.arrayBuffer())
-    .then((b) => new Uint8Array(b));
+await init(); // load the wasm modules once
 
-// 1. Open the COG header with whitebox-wasm's streamer.
-const stream = new CogStream(await range(0, 65535));
-// levels: [{level,width,height,tile_width,tile_height,tiles_x,tiles_y,bands,
-//           bits_per_sample,sample_format,compression}, ...] finest first
-const levels = JSON.parse(stream.levels_json());
+let source = null;
+// The protocol resolves the active source + render settings per tile.
+registerCogProtocol(maplibregl, "cog", () => ({
+  source,
+  render: { min: 0, max: 3000, colormap: "viridis" }, // ignored for paletted COGs
+}));
 
-// 2. Build the tiler from the COG metadata. CogStream's epsg/nodata getters are
-//    Option-typed: a number or `undefined` (not NaN), so pass them straight through.
-const tiler = new CogTiler(
-  Float64Array.from(stream.geo_transform()), // [x0, px_w, rot, y0, rot, px_h]
-  levels[0].width,
-  levels[0].height,
-  stream.epsg, // must be 3857 in v1
-  stream.nodata, // undefined => no nodata
-  JSON.stringify(levels),
-);
+source = await openCog(url); // EPSG:3857 fast path, or warped if projected/4326
+map.addSource("cog", { type: "raster", tiles: ["cog://{z}/{x}/{y}"], tileSize: 256 });
+map.addLayer({ id: "cog", type: "raster", source: "cog" });
 
-// 3. Per XYZ tile: window -> fetch+decode -> render.
-const win = tiler.pixel_window_for_tile(z, x, y);
-// tiles_for_window returns [{col,row,offset,length}]; the tile's pixel origin is
-// (col*tile_width, row*tile_height) and decode_tile_f64 is pixel-interleaved.
-// See demo/index.html `blit()` for the full window-assembly loop.
-const rgba = tiler.render(window, win.w, win.h, 0, 3000, "viridis", true);
+// source.crsLabel, source.levels, source.hasPalette, source.boundsLonLat
+// and source.renderTileRGBA(z, x, y, render) / renderTilePNG(...) are also exposed.
 ```
+
+For a no-build page, map the peer deps with an import map (see
+[`demo/index.html`](demo/index.html)):
+
+```html
+<script type="importmap">
+  { "imports": {
+    "whitebox-wasm": "https://esm.sh/whitebox-wasm@0.4.0",
+    "proj4": "https://esm.sh/proj4@2.20.9",
+    "geotiff": "https://esm.sh/geotiff@2.1.3",
+    "geotiff-geokeys-to-proj4": "https://esm.sh/geotiff-geokeys-to-proj4@2024.4.13"
+  } }
+</script>
+```
+
+### Low-level Rust API
+
+The wasm crate (`CogTiler`) is the 3857 tiling brain underneath `cog-tiler.js`:
+`pixel_window_for_tile(z, x, y)` maps a tile to a source-pixel window/overview,
+and `render(window, w, h, min, max, colormap, nodata_alpha)` rasterizes an
+assembled f64 window to RGBA. See [`demo/cog-tiler.js`](demo/cog-tiler.js) for the
+window-assembly and warp loops built on top.
 
 A runnable MapLibre example (custom `cog://` protocol) is in
 [`demo/index.html`](demo/index.html).

--- a/demo/cog-tiler.js
+++ b/demo/cog-tiler.js
@@ -340,7 +340,8 @@ export async function rgbaToPng(rgba) {
  * `source` is a {@link CogSource} and `render` is `{ min, max, colormap }`.
  */
 export function registerCogProtocol(maplibregl, name, resolve) {
-  const re = new RegExp(`${name}://(\\d+)/(\\d+)/(\\d+)`);
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"); // literal protocol name
+  const re = new RegExp(`${escaped}://(\\d+)/(\\d+)/(\\d+)`);
   maplibregl.addProtocol(name, async (params) => {
     const ctx = resolve();
     if (!ctx || !ctx.source) return { data: new Uint8Array() };

--- a/demo/cog-tiler.js
+++ b/demo/cog-tiler.js
@@ -1,0 +1,357 @@
+/**
+ * cog-tiler-wasm - reusable, client-side COG tiling for MapLibre/Leaflet.
+ *
+ * Wraps whitebox-wasm (`CogStream`: pure-Rust COG decode + HTTP range reads) and
+ * this repo's `CogTiler` (Web Mercator math + rescale/colormap render) into a
+ * tiler that:
+ *   - serves EPSG:3857 COGs directly (fast affine path), and
+ *   - warps any other projected / EPSG:4326 COG to Web Mercator on the fly,
+ *     rendering paletted (categorical) bands through their color table.
+ *
+ * Dependencies are bare module specifiers - provide them through your bundler
+ * (as peer dependencies) or an import map:
+ *   whitebox-wasm, proj4, geotiff, geotiff-geokeys-to-proj4
+ * The wasm package (`cog_tiler_wasm.js` + `_bg.wasm`) must sit next to this file.
+ *
+ * Usage:
+ *   import { init, openCog, registerCogProtocol } from "./cog-tiler.js";
+ *   await init();
+ *   const src = await openCog(url);
+ *   registerCogProtocol(maplibregl, "cog", () => ({ source: src, render: { min, max, colormap } }));
+ *   map.addSource("cog", { type: "raster", tiles: ["cog://{z}/{x}/{y}"], tileSize: 256 });
+ */
+import initWhitebox, { CogStream } from "whitebox-wasm";
+import initTiler, { CogTiler } from "./cog_tiler_wasm.js?v=__BUILD__";
+import proj4 from "proj4";
+import * as GeoTIFF from "geotiff";
+import geokeysToProj4 from "geotiff-geokeys-to-proj4";
+
+const OS = 20037508.342789244; // Web Mercator half-extent (m)
+const TILE = 256; // output tile size (px)
+const NG = 16; // warp grid cells per axis
+const MAX_CACHED_TILES = 256; // ~0.5 MB each at 256x256 f64
+
+proj4.defs(
+  "EPSG:3857",
+  "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
+);
+
+let _ready = null;
+/** Initialize the wasm modules (idempotent). Resolve this before `openCog`. */
+export function init() {
+  if (!_ready) _ready = Promise.all([initWhitebox(), initTiler()]);
+  return _ready;
+}
+
+/** EPSG:3857 bounds [minx,miny,maxx,maxy] of an XYZ tile. */
+function tileBounds3857(z, x, y) {
+  const span = (2 * OS) / 2 ** z;
+  return [-OS + x * span, OS - (y + 1) * span, -OS + (x + 1) * span, OS - y * span];
+}
+
+const rangeFetcher = (url) => (a, b) =>
+  fetch(url, { headers: { Range: `bytes=${a}-${b}` } })
+    .then((r) => r.arrayBuffer())
+    .then((b) => new Uint8Array(b));
+
+/** Build a 256-entry RGBA palette from a TIFF ColorMap (16-bit R,G,B blocks). */
+function buildPalette(colorMap) {
+  if (!colorMap) return null;
+  const n = colorMap.length / 3;
+  const pal = new Uint8ClampedArray(256 * 4);
+  for (let i = 0; i < 256 && i < n; i++) {
+    pal[i * 4] = colorMap[i] >> 8;
+    pal[i * 4 + 1] = colorMap[n + i] >> 8;
+    pal[i * 4 + 2] = colorMap[2 * n + i] >> 8;
+    pal[i * 4 + 3] = 255;
+  }
+  return pal;
+}
+
+function bilin(v00, v10, v01, v11, tx, ty) {
+  if (!isFinite(v00) || !isFinite(v10) || !isFinite(v01) || !isFinite(v11)) {
+    return isFinite(v00) ? v00 : NaN; // near projection edges
+  }
+  const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
+  return top + (bot - top) * ty;
+}
+
+/**
+ * Open a COG and return a {@link CogSource} ready to render XYZ tiles.
+ * Detects EPSG:3857 (fast path) vs. any other CRS (warp path), and reads the
+ * source projection + color table from the GeoTIFF header (whitebox-wasm 0.4.0
+ * does not expose them).
+ */
+export async function openCog(url) {
+  await init();
+  const range = rangeFetcher(url);
+  // Parse the COG header; grow the prefix and retry for large COGs whose IFDs
+  // exceed 64 KB (many overviews / huge tile-offset arrays).
+  let stream;
+  for (let len = 65536; ; len *= 8) {
+    try {
+      stream = new CogStream(await range(0, len - 1));
+      break;
+    } catch (e) {
+      if (len >= 1 << 25) throw e; // give up past ~32 MB
+    }
+  }
+  const gt = stream.geo_transform(); // [x0, px_w, rot, y0, rot, px_h]
+  const levels = JSON.parse(stream.levels_json());
+  if (!Array.isArray(levels) || levels.length === 0) {
+    throw new Error("levels_json() returned no levels");
+  }
+  // CogTiler renders an assembled f64 window -> RGBA (rescale + colormap +
+  // nodata). render() ignores the CRS, so we build one in both modes.
+  const tiler = new CogTiler(
+    Float64Array.from(gt),
+    levels[0].width,
+    levels[0].height,
+    3857,
+    stream.nodata,
+    JSON.stringify(levels),
+  );
+  const base = { url, range, stream, tiler, levels, gt, nodata: stream.nodata };
+
+  if (stream.epsg === 3857) {
+    return new CogSource({
+      ...base,
+      mode: "3857",
+      crsLabel: "EPSG:3857",
+      palette: null,
+      boundsLonLat: Array.from(stream.bounds_lonlat()),
+    });
+  }
+
+  // Warp path: read the real source CRS + optional palette from the header.
+  const tiff = await GeoTIFF.fromUrl(url);
+  const img = await tiff.getImage();
+  const srcDef = geokeysToProj4.toProj4(img.getGeoKeys()).proj4;
+  if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");
+  const toSource = proj4("EPSG:3857", srcDef); // forward: mercator -> source
+  const toLonLat = proj4(srcDef, "EPSG:4326"); // forward: source -> lon/lat
+  const palette = buildPalette(img.fileDirectory.ColorMap);
+
+  // fitBounds bounds: transform the source corners to lon/lat.
+  const fw = levels[0].width, fh = levels[0].height;
+  const corners = [
+    [gt[0], gt[3]],
+    [gt[0] + fw * gt[1], gt[3]],
+    [gt[0], gt[3] + fh * gt[5]],
+    [gt[0] + fw * gt[1], gt[3] + fh * gt[5]],
+  ].map((c) => toLonLat.forward(c));
+  const lons = corners.map((c) => c[0]), lats = corners.map((c) => c[1]);
+
+  return new CogSource({
+    ...base,
+    mode: "warp",
+    toSource,
+    palette,
+    boundsLonLat: [Math.min(...lons), Math.min(...lats), Math.max(...lons), Math.max(...lats)],
+    crsLabel: "warped from " + (srcDef.match(/\+proj=\w+/) || ["custom CRS"])[0],
+  });
+}
+
+/** A single opened COG. Renders XYZ tiles via {@link CogSource#renderTileRGBA}. */
+export class CogSource {
+  constructor(fields) {
+    Object.assign(this, fields);
+    // Decoded source tiles keyed by "level/col/row"; caching the decode lets
+    // panning/zooming reuse overlapping tiles instead of re-fetching/decoding.
+    this.tileCache = new Map();
+  }
+
+  /** True when the band is paletted (categorical) and rendered via its table. */
+  get hasPalette() {
+    return !!this.palette;
+  }
+
+  /** Render an XYZ tile to a 256x256 RGBA `Uint8ClampedArray`, or null if empty. */
+  async renderTileRGBA(z, x, y, opts = {}) {
+    return this.mode === "warp"
+      ? this._warp(z, x, y, opts)
+      : this._render3857(z, x, y, opts);
+  }
+
+  /** Render an XYZ tile to PNG bytes (empty `Uint8Array` for a blank tile). */
+  async renderTilePNG(z, x, y, opts = {}) {
+    const rgba = await this.renderTileRGBA(z, x, y, opts);
+    return rgba ? rgbaToPng(rgba) : new Uint8Array();
+  }
+
+  // --- internals ------------------------------------------------------------
+
+  _getTile(level, t) {
+    const key = level + "/" + t.col + "/" + t.row;
+    let p = this.tileCache.get(key);
+    if (!p) {
+      p = this.range(t.offset, t.offset + t.length - 1)
+        .then((bytes) => this.stream.decode_tile_f64(level, bytes))
+        .catch((err) => {
+          this.tileCache.delete(key); // don't cache failures; allow retry
+          throw err;
+        });
+      this.tileCache.set(key, p);
+      if (this.tileCache.size > MAX_CACHED_TILES) {
+        this.tileCache.delete(this.tileCache.keys().next().value); // evict oldest
+      }
+    }
+    return p;
+  }
+
+  // Fetch (parallel, cached) + decode the source tiles covering a level pixel
+  // window and assemble them into a row-major f64 buffer (NaN = no data).
+  async _assembleWindow(level, x, y, w, h) {
+    const lv = this.levels[level];
+    const tiles = JSON.parse(this.stream.tiles_for_window(level, x, y, w, h));
+    const decoded = await Promise.all(tiles.map((t) => this._getTile(level, t)));
+    const buf = new Float64Array(w * h).fill(NaN);
+    const tw = lv.tile_width, th = lv.tile_height, bands = lv.bands;
+    tiles.forEach((t, i) => {
+      const px = decoded[i];
+      const tx0 = t.col * tw, ty0 = t.row * th;
+      for (let ry = 0; ry < th; ry++) {
+        const oy = ty0 + ry - y;
+        if (oy < 0 || oy >= h) continue;
+        for (let rx = 0; rx < tw; rx++) {
+          const ox = tx0 + rx - x;
+          if (ox < 0 || ox >= w) continue;
+          buf[oy * w + ox] = px[(ry * tw + rx) * bands]; // band 0
+        }
+      }
+    });
+    return buf;
+  }
+
+  // Choose the overview whose source resolution is the coarsest still finer than
+  // `srcRes` (m/px), avoiding upsampling; finest level otherwise.
+  _chooseLevel(srcRes) {
+    const baseRes = Math.abs(this.gt[1]), fw = this.levels[0].width;
+    let best = -1, bestRes = 0, finest = 0, finestRes = Infinity;
+    this.levels.forEach((lv, i) => {
+      const res = baseRes * (fw / lv.width);
+      if (res < finestRes) { finestRes = res; finest = i; }
+      if (res <= srcRes && res > bestRes) { best = i; bestRes = res; }
+    });
+    return best >= 0 ? best : finest;
+  }
+
+  _levelPixelSize(level) {
+    const lv = this.levels[level], L0 = this.levels[0];
+    return [
+      Math.abs(this.gt[1]) * (L0.width / lv.width),
+      Math.abs(this.gt[5]) * (L0.height / lv.height),
+    ];
+  }
+
+  // Fast path: source already EPSG:3857, so a tile maps affinely to a window.
+  async _render3857(z, x, y, { min = 0, max = 1, colormap = "viridis" } = {}) {
+    const win = this.tiler.pixel_window_for_tile(z, x, y);
+    if (win.empty) return null;
+    const buf = await this._assembleWindow(win.level, win.x, win.y, win.w, win.h);
+    return this.tiler.render(buf, win.w, win.h, min, max, colormap, true);
+  }
+
+  // Warp path: reproject a Web Mercator tile from the source CRS on the fly.
+  // A coarse grid of mercator->source samples (proj4) is bilinearly interpolated
+  // per output pixel, then nearest-sampled from the source window (correct for
+  // categorical data). Paletted sources use the color table; others reuse the
+  // Rust colormap (render resamples 256->256, ~identity).
+  async _warp(z, x, y, { min = 0, max = 1, colormap = "viridis" } = {}) {
+    const tb = tileBounds3857(z, x, y);
+    const nx = new Float64Array((NG + 1) * (NG + 1));
+    const ny = new Float64Array((NG + 1) * (NG + 1));
+    let sminx = Infinity, sminy = Infinity, smaxx = -Infinity, smaxy = -Infinity, any = false;
+    for (let gy = 0; gy <= NG; gy++) {
+      const my = tb[3] - (gy / NG) * (tb[3] - tb[1]);
+      for (let gx = 0; gx <= NG; gx++) {
+        const mx = tb[0] + (gx / NG) * (tb[2] - tb[0]);
+        let s;
+        try { s = this.toSource.forward([mx, my]); } catch { s = [NaN, NaN]; }
+        const i = gy * (NG + 1) + gx;
+        nx[i] = s[0]; ny[i] = s[1];
+        if (isFinite(s[0]) && isFinite(s[1])) {
+          any = true;
+          if (s[0] < sminx) sminx = s[0];
+          if (s[0] > smaxx) smaxx = s[0];
+          if (s[1] < sminy) sminy = s[1];
+          if (s[1] > smaxy) smaxy = s[1];
+        }
+      }
+    }
+    if (!any) return null;
+
+    const level = this._chooseLevel((smaxx - sminx) / TILE);
+    const lv = this.levels[level];
+    const [lpw, lph] = this._levelPixelSize(level);
+    const ox = this.gt[0], oy = this.gt[3];
+    let c0 = Math.floor((sminx - ox) / lpw), c1 = Math.ceil((smaxx - ox) / lpw);
+    let r0 = Math.floor((oy - smaxy) / lph), r1 = Math.ceil((oy - sminy) / lph);
+    c0 = Math.max(0, Math.min(c0, lv.width)); c1 = Math.max(0, Math.min(c1, lv.width));
+    r0 = Math.max(0, Math.min(r0, lv.height)); r1 = Math.max(0, Math.min(r1, lv.height));
+    const ww = c1 - c0, hh = r1 - r0;
+    if (ww <= 0 || hh <= 0) return null;
+    const buf = await this._assembleWindow(level, c0, r0, ww, hh);
+
+    const pal = this.palette;
+    const out = new Uint8ClampedArray(TILE * TILE * 4);
+    const grid = pal ? null : new Float64Array(TILE * TILE).fill(NaN);
+    for (let py = 0; py < TILE; py++) {
+      const fy = (py / TILE) * NG, gy0 = Math.min(NG - 1, Math.floor(fy)), ty = fy - gy0;
+      for (let px = 0; px < TILE; px++) {
+        const fx = (px / TILE) * NG, gx0 = Math.min(NG - 1, Math.floor(fx)), tx = fx - gx0;
+        const i00 = gy0 * (NG + 1) + gx0;
+        const sx = bilin(nx[i00], nx[i00 + 1], nx[i00 + NG + 1], nx[i00 + NG + 2], tx, ty);
+        const sy = bilin(ny[i00], ny[i00 + 1], ny[i00 + NG + 1], ny[i00 + NG + 2], tx, ty);
+        if (!isFinite(sx) || !isFinite(sy)) continue;
+        const col = Math.floor((sx - ox) / lpw) - c0;
+        const row = Math.floor((oy - sy) / lph) - r0;
+        if (col < 0 || col >= ww || row < 0 || row >= hh) continue;
+        const v = buf[row * ww + col];
+        if (!isFinite(v)) continue;
+        if (pal) {
+          const ci = v & 255;
+          if (ci === 0 || (this.nodata != null && v === this.nodata)) continue;
+          const o = (py * TILE + px) * 4;
+          out[o] = pal[ci * 4]; out[o + 1] = pal[ci * 4 + 1];
+          out[o + 2] = pal[ci * 4 + 2]; out[o + 3] = 255;
+        } else {
+          grid[py * TILE + px] = v;
+        }
+      }
+    }
+    if (pal) return out;
+    return this.tiler.render(grid, TILE, TILE, min, max, colormap, true);
+  }
+}
+
+/** Encode a 256x256 RGBA buffer to PNG bytes (browser; uses OffscreenCanvas). */
+export async function rgbaToPng(rgba) {
+  const img = new ImageData(new Uint8ClampedArray(rgba), TILE, TILE);
+  const cv = new OffscreenCanvas(TILE, TILE);
+  cv.getContext("2d").putImageData(img, 0, 0);
+  const blob = await cv.convertToBlob({ type: "image/png" });
+  return new Uint8Array(await blob.arrayBuffer());
+}
+
+/**
+ * Register a MapLibre custom protocol (e.g. `cog://{z}/{x}/{y}`).
+ * `resolve()` is called per tile and returns `{ source, render }`, where
+ * `source` is a {@link CogSource} and `render` is `{ min, max, colormap }`.
+ */
+export function registerCogProtocol(maplibregl, name, resolve) {
+  const re = new RegExp(`${name}://(\\d+)/(\\d+)/(\\d+)`);
+  maplibregl.addProtocol(name, async (params) => {
+    const ctx = resolve();
+    if (!ctx || !ctx.source) return { data: new Uint8Array() };
+    const m = params.url.match(re);
+    if (!m) return { data: new Uint8Array() };
+    const [z, x, y] = m.slice(1).map(Number);
+    try {
+      return { data: await ctx.source.renderTilePNG(z, x, y, ctx.render || {}) };
+    } catch (e) {
+      console.error(name, "tile", z, x, y, e);
+      return { data: new Uint8Array() };
+    }
+  });
+}

--- a/demo/index.html
+++ b/demo/index.html
@@ -35,7 +35,7 @@
   <body>
     <div id="panel">
       <strong>cog-tiler-wasm</strong> — serverless COG tiling<br />
-      <small>EPSG:3857 COG URL:</small>
+      <small>COG URL (EPSG:3857, or any projected/4326 - warped on the fly):</small>
       <input id="url" value="./sample-3857-cog.tif" placeholder="https://.../cog-3857.tif" />
       <div>
         rescale
@@ -69,7 +69,26 @@
       // on deploy so a fresh module never pairs with a stale cached loader.
       import initTiler, { CogTiler } from "./cog_tiler_wasm.js?v=__BUILD__";
 
+      // For non-3857 sources we warp on the fly. whitebox-wasm 0.4.0 does not
+      // expose the source projection or color table, so geotiff.js reads those
+      // from the COG header and proj4js does the coordinate transform.
+      import proj4 from "https://esm.sh/proj4@2.20.9";
+      // Pin geotiff 2.x: 3.x defers tag reads, so fileDirectory.ColorMap is empty.
+      import * as GeoTIFF from "https://esm.sh/geotiff@2.1.3";
+      import geokeysToProj4 from "https://esm.sh/geotiff-geokeys-to-proj4@2024.4.13";
+
+      proj4.defs(
+        "EPSG:3857",
+        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
+      );
+
       await Promise.all([initWhitebox(), initTiler()]);
+
+      const OS = 20037508.342789244; // Web Mercator half-extent (m)
+      function tileBounds3857(z, x, y) {
+        const span = (2 * OS) / 2 ** z;
+        return [-OS + x * span, OS - (y + 1) * span, -OS + (x + 1) * span, OS - y * span];
+      }
 
       const status = (m) => (document.getElementById("status").textContent = m);
 
@@ -120,28 +139,68 @@
         if (!Array.isArray(levels) || levels.length === 0) {
           throw new Error("levels_json() returned no levels");
         }
-        // v1 supports EPSG:3857 only. Reject other CRSs up front with a clear
-        // message instead of failing silently per-tile inside the protocol
-        // handler (e.g. NLCD is Albers, so the map would just stay blank).
-        if (stream.epsg !== 3857) {
-          const crs = stream.epsg ? "EPSG:" + stream.epsg : "non-3857 / unknown";
-          throw new Error(
-            `source CRS is ${crs}; this demo (v1) renders EPSG:3857 only - reproject the COG to 3857 first`,
-          );
-        }
-        // CogStream getters are Option -> a number or `undefined` (not NaN).
+        // tileCache: decoded source tiles keyed by "level/col/row". Caching the
+        // decode (not just the bytes) lets panning/zooming reuse overlapping
+        // source tiles instead of re-fetching and re-decoding them.
+        const base = { stream, range, levels, gt, nodata: stream.nodata, tileCache: new Map() };
+
+        // CogTiler renders an assembled f64 window -> RGBA (rescale + colormap +
+        // nodata). render() ignores the CRS, so we build one in both modes.
         const tiler = new CogTiler(
           Float64Array.from(gt),
           levels[0].width,
           levels[0].height,
-          stream.epsg, // must be 3857 in v1
-          stream.nodata, // undefined => no nodata
+          3857,
+          stream.nodata,
           JSON.stringify(levels),
         );
-        // tileCache: decoded source tiles keyed by "level/col/row". Caching the
-        // decode (not just the bytes) means panning/zooming reuses overlapping
-        // source tiles instead of re-fetching and re-decoding them.
-        return { stream, tiler, range, levels, tileCache: new Map() };
+
+        if (stream.epsg === 3857) {
+          // Fast path: source is already Web Mercator, tile windows map affinely.
+          const b = Array.from(stream.bounds_lonlat());
+          return { ...base, mode: "3857", tiler, crsLabel: "EPSG:3857", boundsLonLat: b };
+        }
+
+        // Warp path: read the real source CRS + optional palette from the header
+        // (whitebox doesn't expose them) and set up the 3857 -> source transform.
+        const tiff = await GeoTIFF.fromUrl(url);
+        const geoKeys = (await tiff.getImage()).getGeoKeys();
+        const srcDef = geokeysToProj4.toProj4(geoKeys).proj4;
+        if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");
+        const toSource = proj4("EPSG:3857", srcDef); // forward: mercator -> source
+        const toLonLat = proj4(srcDef, "EPSG:4326"); // forward: source -> lon/lat
+        const palette = buildPalette((await tiff.getImage()).fileDirectory.ColorMap);
+
+        // fitBounds bounds: transform the source corners to lon/lat.
+        const fw = levels[0].width, fh = levels[0].height;
+        const corners = [
+          [gt[0], gt[3]],
+          [gt[0] + fw * gt[1], gt[3]],
+          [gt[0], gt[3] + fh * gt[5]],
+          [gt[0] + fw * gt[1], gt[3] + fh * gt[5]],
+        ].map((c) => toLonLat.forward(c));
+        const lons = corners.map((c) => c[0]), lats = corners.map((c) => c[1]);
+        const boundsLonLat = [Math.min(...lons), Math.min(...lats), Math.max(...lons), Math.max(...lats)];
+
+        return {
+          ...base, mode: "warp", tiler, toSource, palette, boundsLonLat,
+          crsLabel: "warped from " + (srcDef.match(/\+proj=\w+/) || ["custom CRS"])[0],
+        };
+      }
+
+      // Build a 256-entry RGBA palette from a TIFF ColorMap (16-bit R,G,B blocks),
+      // or null if the band isn't paletted.
+      function buildPalette(colorMap) {
+        if (!colorMap) return null;
+        const n = colorMap.length / 3;
+        const pal = new Uint8ClampedArray(256 * 4);
+        for (let i = 0; i < 256 && i < n; i++) {
+          pal[i * 4] = colorMap[i] >> 8;
+          pal[i * 4 + 1] = colorMap[n + i] >> 8;
+          pal[i * 4 + 2] = colorMap[2 * n + i] >> 8;
+          pal[i * 4 + 3] = 255;
+        }
+        return pal;
       }
 
       // Fetch + decode one source tile, deduped and cached. Stores the promise
@@ -172,33 +231,152 @@
       // MapLibre custom protocol: cog://{z}/{x}/{y}
       maplibregl.addProtocol("cog", async (params) => {
         if (!current) return { data: new Uint8Array() };
-        const { stream, tiler, levels } = current;
+        const cur = current;
         const m = params.url.match(/cog:\/\/(\d+)\/(\d+)\/(\d+)/);
         const [z, x, y] = m.slice(1).map(Number);
-
-        const win = tiler.pixel_window_for_tile(z, x, y);
-        if (win.empty) return { data: transparentPng() };
-
-        // Ask CogStream which COG tiles cover the window, fetch + decode them,
-        // and assemble a row-major f64 window.
-        const lv = levels[win.level];
-        const tiles = JSON.parse(
-          stream.tiles_for_window(win.level, win.x, win.y, win.w, win.h),
-        );
-        // Fetch + decode all covering tiles in parallel (cached/deduped), then
-        // assemble them into a row-major f64 window.
-        const decoded = await Promise.all(
-          tiles.map((t) => getTile(current, win.level, t)),
-        );
-        const window = new Float64Array(win.w * win.h);
-        tiles.forEach((t, i) => blit(decoded[i], t, win, lv, window));
-
-        const min = +document.getElementById("min").value;
-        const max = +document.getElementById("max").value;
-        const cmap = document.getElementById("cmap").value;
-        const rgba = tiler.render(window, win.w, win.h, min, max, cmap, true);
-        return { data: await rgbaToPng(rgba) };
+        try {
+          const rgba =
+            cur.mode === "warp"
+              ? await warpTile(cur, z, x, y)
+              : await renderTile3857(cur, z, x, y);
+          return rgba ? { data: await rgbaToPng(rgba) } : { data: transparentPng() };
+        } catch (e) {
+          console.error("cog tile", z, x, y, e);
+          return { data: transparentPng() };
+        }
       });
+
+      function readUI() {
+        return {
+          min: +document.getElementById("min").value,
+          max: +document.getElementById("max").value,
+          cmap: document.getElementById("cmap").value,
+        };
+      }
+
+      // Fetch + decode (parallel, cached) the source tiles covering a level
+      // pixel window and assemble them into a row-major f64 buffer (NaN = no data).
+      async function assembleWindow(cur, level, x, y, w, h) {
+        const lv = cur.levels[level];
+        const tiles = JSON.parse(cur.stream.tiles_for_window(level, x, y, w, h));
+        const decoded = await Promise.all(tiles.map((t) => getTile(cur, level, t)));
+        const buf = new Float64Array(w * h).fill(NaN);
+        const win = { x, y, w, h };
+        tiles.forEach((t, i) => blit(decoded[i], t, win, lv, buf));
+        return buf;
+      }
+
+      // Fast path: source already EPSG:3857, so a tile maps affinely to a window.
+      async function renderTile3857(cur, z, x, y) {
+        const win = cur.tiler.pixel_window_for_tile(z, x, y);
+        if (win.empty) return null;
+        const buf = await assembleWindow(cur, win.level, win.x, win.y, win.w, win.h);
+        const { min, max, cmap } = readUI();
+        return cur.tiler.render(buf, win.w, win.h, min, max, cmap, true);
+      }
+
+      // Choose the overview whose source resolution is the coarsest still finer
+      // than `srcRes` (meters/px), avoiding upsampling; finest level otherwise.
+      function chooseLevel(cur, srcRes) {
+        const base = Math.abs(cur.gt[1]), fw = cur.levels[0].width;
+        let best = -1, bestRes = 0, finest = 0, finestRes = Infinity;
+        cur.levels.forEach((lv, i) => {
+          const res = base * (fw / lv.width);
+          if (res < finestRes) { finestRes = res; finest = i; }
+          if (res <= srcRes && res > bestRes) { best = i; bestRes = res; }
+        });
+        return best >= 0 ? best : finest;
+      }
+
+      function levelPixelSize(cur, level) {
+        const lv = cur.levels[level], L0 = cur.levels[0];
+        return [
+          Math.abs(cur.gt[1]) * (L0.width / lv.width),
+          Math.abs(cur.gt[5]) * (L0.height / lv.height),
+        ];
+      }
+
+      function bilin(v00, v10, v01, v11, tx, ty) {
+        if (!isFinite(v00) || !isFinite(v10) || !isFinite(v01) || !isFinite(v11)) {
+          return isFinite(v00) ? v00 : NaN; // near projection edges
+        }
+        const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
+        return top + (bot - top) * ty;
+      }
+
+      // Warp path: reproject a Web Mercator tile from the source CRS on the fly.
+      // A coarse grid of mercator->source samples (proj4) is bilinearly
+      // interpolated per output pixel, then nearest-sampled from the source
+      // window. Paletted sources use the color table; others reuse the Rust
+      // colormap (render resamples 256->256, ~identity).
+      const NG = 16; // warp grid cells per axis
+      async function warpTile(cur, z, x, y) {
+        const tb = tileBounds3857(z, x, y);
+        const nx = new Float64Array((NG + 1) * (NG + 1));
+        const ny = new Float64Array((NG + 1) * (NG + 1));
+        let sminx = Infinity, sminy = Infinity, smaxx = -Infinity, smaxy = -Infinity, any = false;
+        for (let gy = 0; gy <= NG; gy++) {
+          const my = tb[3] - (gy / NG) * (tb[3] - tb[1]);
+          for (let gx = 0; gx <= NG; gx++) {
+            const mx = tb[0] + (gx / NG) * (tb[2] - tb[0]);
+            let s;
+            try { s = cur.toSource.forward([mx, my]); } catch { s = [NaN, NaN]; }
+            const i = gy * (NG + 1) + gx;
+            nx[i] = s[0]; ny[i] = s[1];
+            if (isFinite(s[0]) && isFinite(s[1])) {
+              any = true;
+              if (s[0] < sminx) sminx = s[0];
+              if (s[0] > smaxx) smaxx = s[0];
+              if (s[1] < sminy) sminy = s[1];
+              if (s[1] > smaxy) smaxy = s[1];
+            }
+          }
+        }
+        if (!any) return null;
+
+        const level = chooseLevel(cur, (smaxx - sminx) / 256);
+        const lv = cur.levels[level];
+        const [lpw, lph] = levelPixelSize(cur, level);
+        const ox = cur.gt[0], oy = cur.gt[3];
+        let c0 = Math.floor((sminx - ox) / lpw), c1 = Math.ceil((smaxx - ox) / lpw);
+        let r0 = Math.floor((oy - smaxy) / lph), r1 = Math.ceil((oy - sminy) / lph);
+        c0 = Math.max(0, Math.min(c0, lv.width)); c1 = Math.max(0, Math.min(c1, lv.width));
+        r0 = Math.max(0, Math.min(r0, lv.height)); r1 = Math.max(0, Math.min(r1, lv.height));
+        const ww = c1 - c0, hh = r1 - r0;
+        if (ww <= 0 || hh <= 0) return null;
+        const buf = await assembleWindow(cur, level, c0, r0, ww, hh);
+
+        const pal = cur.palette;
+        const ui = pal ? null : readUI();
+        const out = new Uint8ClampedArray(256 * 256 * 4);
+        const grid = pal ? null : new Float64Array(256 * 256).fill(NaN);
+        for (let py = 0; py < 256; py++) {
+          const fy = (py / 256) * NG, gy0 = Math.min(NG - 1, Math.floor(fy)), ty = fy - gy0;
+          for (let px = 0; px < 256; px++) {
+            const fx = (px / 256) * NG, gx0 = Math.min(NG - 1, Math.floor(fx)), tx = fx - gx0;
+            const i00 = gy0 * (NG + 1) + gx0;
+            const sx = bilin(nx[i00], nx[i00 + 1], nx[i00 + NG + 1], nx[i00 + NG + 2], tx, ty);
+            const sy = bilin(ny[i00], ny[i00 + 1], ny[i00 + NG + 1], ny[i00 + NG + 2], tx, ty);
+            if (!isFinite(sx) || !isFinite(sy)) continue;
+            const col = Math.floor((sx - ox) / lpw) - c0;
+            const row = Math.floor((oy - sy) / lph) - r0;
+            if (col < 0 || col >= ww || row < 0 || row >= hh) continue;
+            const v = buf[row * ww + col];
+            if (!isFinite(v)) continue;
+            if (pal) {
+              const ci = v & 255;
+              if (ci === 0 || (cur.nodata != null && v === cur.nodata)) continue;
+              const o = (py * 256 + px) * 4;
+              out[o] = pal[ci * 4]; out[o + 1] = pal[ci * 4 + 1];
+              out[o + 2] = pal[ci * 4 + 2]; out[o + 3] = 255;
+            } else {
+              grid[py * 256 + px] = v;
+            }
+          }
+        }
+        if (pal) return out;
+        return cur.tiler.render(grid, 256, 256, ui.min, ui.max, ui.cmap, true);
+      }
 
       async function load() {
         const url = document.getElementById("url").value.trim();
@@ -206,7 +384,10 @@
         status("opening COG…");
         try {
           current = await openCog(url);
-          status(`EPSG:${current.tiler.epsg}, ${current.tiler.num_levels} levels`);
+          status(
+            `${current.crsLabel}, ${current.levels.length} levels` +
+              (current.palette ? " (palette)" : ""),
+          );
           if (map.getLayer("cog")) map.removeLayer("cog");
           if (map.getSource("cog")) map.removeSource("cog");
           map.addSource("cog", {
@@ -215,9 +396,9 @@
             tileSize: 256,
           });
           map.addLayer({ id: "cog", type: "raster", source: "cog" });
-          // Zoom to the data: bounds_lonlat() -> [minlon,minlat,maxlon,maxlat].
-          const b = Array.from(current.stream.bounds_lonlat());
-          if (b.length === 4) {
+          // Zoom to the data: boundsLonLat = [minlon,minlat,maxlon,maxlat].
+          const b = current.boundsLonLat;
+          if (b && b.length === 4 && b.every(Number.isFinite)) {
             map.fitBounds([[b[0], b[1]], [b[2], b[3]]], { padding: 20, duration: 0 });
           }
         } catch (e) {

--- a/demo/index.html
+++ b/demo/index.html
@@ -164,12 +164,13 @@
         // Warp path: read the real source CRS + optional palette from the header
         // (whitebox doesn't expose them) and set up the 3857 -> source transform.
         const tiff = await GeoTIFF.fromUrl(url);
-        const geoKeys = (await tiff.getImage()).getGeoKeys();
+        const img = await tiff.getImage();
+        const geoKeys = img.getGeoKeys();
         const srcDef = geokeysToProj4.toProj4(geoKeys).proj4;
         if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");
         const toSource = proj4("EPSG:3857", srcDef); // forward: mercator -> source
         const toLonLat = proj4(srcDef, "EPSG:4326"); // forward: source -> lon/lat
-        const palette = buildPalette((await tiff.getImage()).fileDirectory.ColorMap);
+        const palette = buildPalette(img.fileDirectory.ColorMap);
 
         // fitBounds bounds: transform the source corners to lon/lat.
         const fw = levels[0].width, fh = levels[0].height;

--- a/demo/index.html
+++ b/demo/index.html
@@ -8,6 +8,18 @@
       href="https://unpkg.com/maplibre-gl@5.24.0/dist/maplibre-gl.css"
       rel="stylesheet"
     />
+    <!-- Resolve the cog-tiler.js peer dependencies to a CDN for this no-build
+         demo. In a bundled app these are normal npm peer dependencies. -->
+    <script type="importmap">
+      {
+        "imports": {
+          "whitebox-wasm": "https://esm.sh/whitebox-wasm@0.4.0",
+          "proj4": "https://esm.sh/proj4@2.20.9",
+          "geotiff": "https://esm.sh/geotiff@2.1.3",
+          "geotiff-geokeys-to-proj4": "https://esm.sh/geotiff-geokeys-to-proj4@2024.4.13"
+        }
+      }
+    </script>
     <style>
       html,
       body,
@@ -59,38 +71,19 @@
 
     <script type="module">
       import maplibregl from "https://esm.sh/maplibre-gl@5.24.0";
+      // All COG tiling/warping/palette logic lives in the reusable module so
+      // downstream apps can import it directly instead of copying this page.
+      // `?v=__BUILD__` is rewritten to the commit SHA on deploy for cache-busting.
+      import { init, openCog, registerCogProtocol } from "./cog-tiler.js?v=__BUILD__";
 
-      // The decode engine (pure-Rust COG codecs + remote range reads).
-      import initWhitebox, {
-        CogStream,
-      } from "https://esm.sh/whitebox-wasm@0.4.0";
-      // The tiling brain (this crate). The Pages workflow builds the wasm
-      // package next to this file; `?v=__BUILD__` is rewritten to the commit SHA
-      // on deploy so a fresh module never pairs with a stale cached loader.
-      import initTiler, { CogTiler } from "./cog_tiler_wasm.js?v=__BUILD__";
-
-      // For non-3857 sources we warp on the fly. whitebox-wasm 0.4.0 does not
-      // expose the source projection or color table, so geotiff.js reads those
-      // from the COG header and proj4js does the coordinate transform.
-      import proj4 from "https://esm.sh/proj4@2.20.9";
-      // Pin geotiff 2.x: 3.x defers tag reads, so fileDirectory.ColorMap is empty.
-      import * as GeoTIFF from "https://esm.sh/geotiff@2.1.3";
-      import geokeysToProj4 from "https://esm.sh/geotiff-geokeys-to-proj4@2024.4.13";
-
-      proj4.defs(
-        "EPSG:3857",
-        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs",
-      );
-
-      await Promise.all([initWhitebox(), initTiler()]);
-
-      const OS = 20037508.342789244; // Web Mercator half-extent (m)
-      function tileBounds3857(z, x, y) {
-        const span = (2 * OS) / 2 ** z;
-        return [-OS + x * span, OS - (y + 1) * span, -OS + (x + 1) * span, OS - y * span];
-      }
+      await init();
 
       const status = (m) => (document.getElementById("status").textContent = m);
+      const readRender = () => ({
+        min: +document.getElementById("min").value,
+        max: +document.getElementById("max").value,
+        colormap: document.getElementById("cmap").value,
+      });
 
       const map = new maplibregl.Map({
         container: "map",
@@ -99,9 +92,7 @@
           sources: {
             osm: {
               type: "raster",
-              tiles: [
-                "https://tile.openstreetmap.org/{z}/{x}/{y}.png",
-              ],
+              tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
               tileSize: 256,
               attribution: "© OpenStreetMap",
             },
@@ -112,272 +103,12 @@
         zoom: 2,
       });
 
-      // One range-fetch helper per source URL.
-      const rangeFetcher = (url) => (a, b) =>
-        fetch(url, { headers: { Range: `bytes=${a}-${b}` } })
-          .then((r) => r.arrayBuffer())
-          .then((b) => new Uint8Array(b));
-
-      // Build a {stream, tiler, levels} bundle for a COG URL.
-      async function openCog(url) {
-        const range = rangeFetcher(url);
-        // Parse the COG header. Large COGs (many overviews / huge tile-offset
-        // arrays) have headers bigger than 64 KB, so grow the prefix and retry.
-        let stream;
-        for (let len = 65536; ; len *= 8) {
-          try {
-            stream = new CogStream(await range(0, len - 1));
-            break;
-          } catch (e) {
-            if (len >= 1 << 25) throw e; // give up past ~32 MB
-          }
-        }
-        const gt = stream.geo_transform(); // [x0, px_w, rot, y0, rot, px_h]
-        // levels: [{level,width,height,tile_width,tile_height,tiles_x,tiles_y,
-        //           bands,bits_per_sample,sample_format,compression}, ...]
-        const levels = JSON.parse(stream.levels_json());
-        if (!Array.isArray(levels) || levels.length === 0) {
-          throw new Error("levels_json() returned no levels");
-        }
-        // tileCache: decoded source tiles keyed by "level/col/row". Caching the
-        // decode (not just the bytes) lets panning/zooming reuse overlapping
-        // source tiles instead of re-fetching and re-decoding them.
-        const base = { stream, range, levels, gt, nodata: stream.nodata, tileCache: new Map() };
-
-        // CogTiler renders an assembled f64 window -> RGBA (rescale + colormap +
-        // nodata). render() ignores the CRS, so we build one in both modes.
-        const tiler = new CogTiler(
-          Float64Array.from(gt),
-          levels[0].width,
-          levels[0].height,
-          3857,
-          stream.nodata,
-          JSON.stringify(levels),
-        );
-
-        if (stream.epsg === 3857) {
-          // Fast path: source is already Web Mercator, tile windows map affinely.
-          const b = Array.from(stream.bounds_lonlat());
-          return { ...base, mode: "3857", tiler, crsLabel: "EPSG:3857", boundsLonLat: b };
-        }
-
-        // Warp path: read the real source CRS + optional palette from the header
-        // (whitebox doesn't expose them) and set up the 3857 -> source transform.
-        const tiff = await GeoTIFF.fromUrl(url);
-        const img = await tiff.getImage();
-        const geoKeys = img.getGeoKeys();
-        const srcDef = geokeysToProj4.toProj4(geoKeys).proj4;
-        if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");
-        const toSource = proj4("EPSG:3857", srcDef); // forward: mercator -> source
-        const toLonLat = proj4(srcDef, "EPSG:4326"); // forward: source -> lon/lat
-        const palette = buildPalette(img.fileDirectory.ColorMap);
-
-        // fitBounds bounds: transform the source corners to lon/lat.
-        const fw = levels[0].width, fh = levels[0].height;
-        const corners = [
-          [gt[0], gt[3]],
-          [gt[0] + fw * gt[1], gt[3]],
-          [gt[0], gt[3] + fh * gt[5]],
-          [gt[0] + fw * gt[1], gt[3] + fh * gt[5]],
-        ].map((c) => toLonLat.forward(c));
-        const lons = corners.map((c) => c[0]), lats = corners.map((c) => c[1]);
-        const boundsLonLat = [Math.min(...lons), Math.min(...lats), Math.max(...lons), Math.max(...lats)];
-
-        return {
-          ...base, mode: "warp", tiler, toSource, palette, boundsLonLat,
-          crsLabel: "warped from " + (srcDef.match(/\+proj=\w+/) || ["custom CRS"])[0],
-        };
-      }
-
-      // Build a 256-entry RGBA palette from a TIFF ColorMap (16-bit R,G,B blocks),
-      // or null if the band isn't paletted.
-      function buildPalette(colorMap) {
-        if (!colorMap) return null;
-        const n = colorMap.length / 3;
-        const pal = new Uint8ClampedArray(256 * 4);
-        for (let i = 0; i < 256 && i < n; i++) {
-          pal[i * 4] = colorMap[i] >> 8;
-          pal[i * 4 + 1] = colorMap[n + i] >> 8;
-          pal[i * 4 + 2] = colorMap[2 * n + i] >> 8;
-          pal[i * 4 + 3] = 255;
-        }
-        return pal;
-      }
-
-      // Fetch + decode one source tile, deduped and cached. Stores the promise
-      // so concurrent map tiles needing the same source tile share one request.
-      const MAX_CACHED_TILES = 256; // ~0.5 MB each at 256x256 f64
-      function getTile(cur, level, t) {
-        const key = level + "/" + t.col + "/" + t.row;
-        let p = cur.tileCache.get(key);
-        if (!p) {
-          p = cur
-            .range(t.offset, t.offset + t.length - 1)
-            .then((bytes) => cur.stream.decode_tile_f64(level, bytes))
-            .catch((err) => {
-              // Don't cache failures, so a transient error can be retried.
-              cur.tileCache.delete(key);
-              throw err;
-            });
-          cur.tileCache.set(key, p);
-          if (cur.tileCache.size > MAX_CACHED_TILES) {
-            cur.tileCache.delete(cur.tileCache.keys().next().value); // evict oldest
-          }
-        }
-        return p;
-      }
-
       let current = null;
-
-      // MapLibre custom protocol: cog://{z}/{x}/{y}
-      maplibregl.addProtocol("cog", async (params) => {
-        if (!current) return { data: new Uint8Array() };
-        const cur = current;
-        const m = params.url.match(/cog:\/\/(\d+)\/(\d+)\/(\d+)/);
-        const [z, x, y] = m.slice(1).map(Number);
-        try {
-          const rgba =
-            cur.mode === "warp"
-              ? await warpTile(cur, z, x, y)
-              : await renderTile3857(cur, z, x, y);
-          return rgba ? { data: await rgbaToPng(rgba) } : { data: transparentPng() };
-        } catch (e) {
-          console.error("cog tile", z, x, y, e);
-          return { data: transparentPng() };
-        }
-      });
-
-      function readUI() {
-        return {
-          min: +document.getElementById("min").value,
-          max: +document.getElementById("max").value,
-          cmap: document.getElementById("cmap").value,
-        };
-      }
-
-      // Fetch + decode (parallel, cached) the source tiles covering a level
-      // pixel window and assemble them into a row-major f64 buffer (NaN = no data).
-      async function assembleWindow(cur, level, x, y, w, h) {
-        const lv = cur.levels[level];
-        const tiles = JSON.parse(cur.stream.tiles_for_window(level, x, y, w, h));
-        const decoded = await Promise.all(tiles.map((t) => getTile(cur, level, t)));
-        const buf = new Float64Array(w * h).fill(NaN);
-        const win = { x, y, w, h };
-        tiles.forEach((t, i) => blit(decoded[i], t, win, lv, buf));
-        return buf;
-      }
-
-      // Fast path: source already EPSG:3857, so a tile maps affinely to a window.
-      async function renderTile3857(cur, z, x, y) {
-        const win = cur.tiler.pixel_window_for_tile(z, x, y);
-        if (win.empty) return null;
-        const buf = await assembleWindow(cur, win.level, win.x, win.y, win.w, win.h);
-        const { min, max, cmap } = readUI();
-        return cur.tiler.render(buf, win.w, win.h, min, max, cmap, true);
-      }
-
-      // Choose the overview whose source resolution is the coarsest still finer
-      // than `srcRes` (meters/px), avoiding upsampling; finest level otherwise.
-      function chooseLevel(cur, srcRes) {
-        const base = Math.abs(cur.gt[1]), fw = cur.levels[0].width;
-        let best = -1, bestRes = 0, finest = 0, finestRes = Infinity;
-        cur.levels.forEach((lv, i) => {
-          const res = base * (fw / lv.width);
-          if (res < finestRes) { finestRes = res; finest = i; }
-          if (res <= srcRes && res > bestRes) { best = i; bestRes = res; }
-        });
-        return best >= 0 ? best : finest;
-      }
-
-      function levelPixelSize(cur, level) {
-        const lv = cur.levels[level], L0 = cur.levels[0];
-        return [
-          Math.abs(cur.gt[1]) * (L0.width / lv.width),
-          Math.abs(cur.gt[5]) * (L0.height / lv.height),
-        ];
-      }
-
-      function bilin(v00, v10, v01, v11, tx, ty) {
-        if (!isFinite(v00) || !isFinite(v10) || !isFinite(v01) || !isFinite(v11)) {
-          return isFinite(v00) ? v00 : NaN; // near projection edges
-        }
-        const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
-        return top + (bot - top) * ty;
-      }
-
-      // Warp path: reproject a Web Mercator tile from the source CRS on the fly.
-      // A coarse grid of mercator->source samples (proj4) is bilinearly
-      // interpolated per output pixel, then nearest-sampled from the source
-      // window. Paletted sources use the color table; others reuse the Rust
-      // colormap (render resamples 256->256, ~identity).
-      const NG = 16; // warp grid cells per axis
-      async function warpTile(cur, z, x, y) {
-        const tb = tileBounds3857(z, x, y);
-        const nx = new Float64Array((NG + 1) * (NG + 1));
-        const ny = new Float64Array((NG + 1) * (NG + 1));
-        let sminx = Infinity, sminy = Infinity, smaxx = -Infinity, smaxy = -Infinity, any = false;
-        for (let gy = 0; gy <= NG; gy++) {
-          const my = tb[3] - (gy / NG) * (tb[3] - tb[1]);
-          for (let gx = 0; gx <= NG; gx++) {
-            const mx = tb[0] + (gx / NG) * (tb[2] - tb[0]);
-            let s;
-            try { s = cur.toSource.forward([mx, my]); } catch { s = [NaN, NaN]; }
-            const i = gy * (NG + 1) + gx;
-            nx[i] = s[0]; ny[i] = s[1];
-            if (isFinite(s[0]) && isFinite(s[1])) {
-              any = true;
-              if (s[0] < sminx) sminx = s[0];
-              if (s[0] > smaxx) smaxx = s[0];
-              if (s[1] < sminy) sminy = s[1];
-              if (s[1] > smaxy) smaxy = s[1];
-            }
-          }
-        }
-        if (!any) return null;
-
-        const level = chooseLevel(cur, (smaxx - sminx) / 256);
-        const lv = cur.levels[level];
-        const [lpw, lph] = levelPixelSize(cur, level);
-        const ox = cur.gt[0], oy = cur.gt[3];
-        let c0 = Math.floor((sminx - ox) / lpw), c1 = Math.ceil((smaxx - ox) / lpw);
-        let r0 = Math.floor((oy - smaxy) / lph), r1 = Math.ceil((oy - sminy) / lph);
-        c0 = Math.max(0, Math.min(c0, lv.width)); c1 = Math.max(0, Math.min(c1, lv.width));
-        r0 = Math.max(0, Math.min(r0, lv.height)); r1 = Math.max(0, Math.min(r1, lv.height));
-        const ww = c1 - c0, hh = r1 - r0;
-        if (ww <= 0 || hh <= 0) return null;
-        const buf = await assembleWindow(cur, level, c0, r0, ww, hh);
-
-        const pal = cur.palette;
-        const ui = pal ? null : readUI();
-        const out = new Uint8ClampedArray(256 * 256 * 4);
-        const grid = pal ? null : new Float64Array(256 * 256).fill(NaN);
-        for (let py = 0; py < 256; py++) {
-          const fy = (py / 256) * NG, gy0 = Math.min(NG - 1, Math.floor(fy)), ty = fy - gy0;
-          for (let px = 0; px < 256; px++) {
-            const fx = (px / 256) * NG, gx0 = Math.min(NG - 1, Math.floor(fx)), tx = fx - gx0;
-            const i00 = gy0 * (NG + 1) + gx0;
-            const sx = bilin(nx[i00], nx[i00 + 1], nx[i00 + NG + 1], nx[i00 + NG + 2], tx, ty);
-            const sy = bilin(ny[i00], ny[i00 + 1], ny[i00 + NG + 1], ny[i00 + NG + 2], tx, ty);
-            if (!isFinite(sx) || !isFinite(sy)) continue;
-            const col = Math.floor((sx - ox) / lpw) - c0;
-            const row = Math.floor((oy - sy) / lph) - r0;
-            if (col < 0 || col >= ww || row < 0 || row >= hh) continue;
-            const v = buf[row * ww + col];
-            if (!isFinite(v)) continue;
-            if (pal) {
-              const ci = v & 255;
-              if (ci === 0 || (cur.nodata != null && v === cur.nodata)) continue;
-              const o = (py * 256 + px) * 4;
-              out[o] = pal[ci * 4]; out[o + 1] = pal[ci * 4 + 1];
-              out[o + 2] = pal[ci * 4 + 2]; out[o + 3] = 255;
-            } else {
-              grid[py * 256 + px] = v;
-            }
-          }
-        }
-        if (pal) return out;
-        return cur.tiler.render(grid, 256, 256, ui.min, ui.max, ui.cmap, true);
-      }
+      // The protocol resolves the active source + current render settings per tile.
+      registerCogProtocol(maplibregl, "cog", () => ({
+        source: current,
+        render: readRender(),
+      }));
 
       async function load() {
         const url = document.getElementById("url").value.trim();
@@ -387,7 +118,7 @@
           current = await openCog(url);
           status(
             `${current.crsLabel}, ${current.levels.length} levels` +
-              (current.palette ? " (palette)" : ""),
+              (current.hasPalette ? " (palette)" : ""),
           );
           if (map.getLayer("cog")) map.removeLayer("cog");
           if (map.getSource("cog")) map.removeSource("cog");
@@ -412,48 +143,6 @@
       if (document.getElementById("url").value.trim()) {
         if (map.loaded()) load();
         else map.on("load", load);
-      }
-
-      // --- small helpers --------------------------------------------------
-
-      // Place a decoded COG tile into the assembled window buffer.
-      // CogStream.tiles_for_window records are { col, row, offset, length } - the
-      // tile's pixel origin in the level is (col*tile_width, row*tile_height),
-      // and decode_tile_f64 returns a full tile_width*tile_height*bands buffer,
-      // pixel-interleaved (stride by `bands` for band 0). Edge tiles come back
-      // full-size; the bounds checks clip them. (Shapes pinned against a real
-      // EPSG:3857 COG, whitebox-wasm 0.4.0.)
-      function blit(tilePx, t, win, lv, out) {
-        const tw = lv.tile_width;
-        const th = lv.tile_height;
-        const bands = lv.bands;
-        const tx0 = t.col * tw;
-        const ty0 = t.row * th;
-        for (let ry = 0; ry < th; ry++) {
-          const oy = ty0 + ry - win.y;
-          if (oy < 0 || oy >= win.h) continue;
-          for (let rx = 0; rx < tw; rx++) {
-            const ox = tx0 + rx - win.x;
-            if (ox < 0 || ox >= win.w) continue;
-            out[oy * win.w + ox] = tilePx[(ry * tw + rx) * bands]; // band 0
-          }
-        }
-      }
-
-      async function rgbaToPng(rgba) {
-        const img = new ImageData(new Uint8ClampedArray(rgba), 256, 256);
-        const cv = new OffscreenCanvas(256, 256);
-        cv.getContext("2d").putImageData(img, 0, 0);
-        const blob = await cv.convertToBlob({ type: "image/png" });
-        return new Uint8Array(await blob.arrayBuffer());
-      }
-
-      let _blank;
-      function transparentPng() {
-        if (_blank) return _blank;
-        const cv = new OffscreenCanvas(256, 256);
-        // a 1x1 transparent canvas scaled is fine; keep it simple
-        return (_blank = new Uint8Array());
       }
     </script>
   </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -79,11 +79,15 @@
       await init();
 
       const status = (m) => (document.getElementById("status").textContent = m);
-      const readRender = () => ({
-        min: +document.getElementById("min").value,
-        max: +document.getElementById("max").value,
-        colormap: document.getElementById("cmap").value,
-      });
+      const num = (id, fallback) => {
+        const v = Number(document.getElementById(id).value);
+        return Number.isFinite(v) ? v : fallback;
+      };
+      const readRender = () => {
+        let min = num("min", 0), max = num("max", 1);
+        if (min >= max) max = min + 1; // avoid a zero/negative rescale range
+        return { min, max, colormap: document.getElementById("cmap").value };
+      };
 
       const map = new maplibregl.Map({
         container: "map",


### PR DESCRIPTION
Renders non-EPSG:3857 and paletted COGs (e.g. `nlcd_2021_land_cover_90m.tif`, Albers + color table), and - per review feedback - ships the logic as a **reusable ESM module** so downstream apps import it instead of copying the demo HTML.

## Reusable module: `demo/cog-tiler.js`

Exports `init()`, `openCog(url) -> CogSource` (`.renderTileRGBA`/`.renderTilePNG`, `.crsLabel`, `.levels`, `.hasPalette`, `.boundsLonLat`), and `registerCogProtocol(maplibregl, name, resolve)`. Wraps whitebox-wasm + the wasm `CogTiler`. Peer deps (`whitebox-wasm`, `proj4`, `geotiff`, `geotiff-geokeys-to-proj4`) are bare imports - resolved by a bundler downstream, or an import map in the no-build demo. `demo/index.html` is now just UI + map wiring.

## Capabilities

- **Warp**: non-3857 tiles are reprojected on the fly - a 16×16 grid of Web-Mercator->source samples (proj4js), bilinearly interpolated per pixel, nearest-sampled (correct for categorical). 3857 stays on the fast affine path.
- **CRS + palette**: whitebox-wasm 0.4.0 exposes neither, so geotiff.js reads the GeoKeys (-> proj4 via `geotiff-geokeys-to-proj4`) and the `ColorMap`. geotiff pinned to **2.x** (3.x defers tag reads, leaving ColorMap empty).
- **Render**: paletted bands via the color table (class 0 / nodata transparent); continuous via the Rust colormap. Plus large-header retry, decoded-tile cache (parallel + deduped), and `fitBounds` from transformed corners.

## Verified (browser, real source.coop files, via the module)

- **NLCD**: warps over CONUS with correct land-cover colors (Great Lakes, urban, forest, cropland placed correctly); status "warped from +proj=aea, 8 levels (palette)".
- **3857 sample** + **dem.tif**: still render (fast path).

## Notes / limits

- Adds 3 CDN peer deps to the demo; whitebox + cog-tiler-wasm still do decode + colormap.
- Non-meter projected-unit conversion not applied (NLCD/most are meters).
- Exposing proj string + color table **upstream in whitebox-wasm** (it already parses both) would drop the geotiff.js dep - noted as a follow-up. Moving warp into the Rust crate (proj4rs) is the longer-term roadmap item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reusable client-side COG tiler module with initialization, source opening, and tile rendering (including paletted COG support).
  * Enabled MapLibre `cog://` protocol handling that fetches, decodes, warps (when needed), and serves tiles.
  * Updated the demo to load required libraries via an import map for no-build usage.
* **Bug Fixes**
  * Improved “zoom to data” to use the source’s available lon/lat bounds when provided.
* **Documentation**
  * Updated the README with new usage instructions and a clearer Rust API reference.
* **Chores**
  * Adjusted the Pages build to copy the new demo module and example asset, with improved cache-busting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->