### PR TITLE
chore(demo): use remote source.coop dem.tif as the default sample

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -48,7 +48,7 @@
     <div id="panel">
       <strong>cog-tiler-wasm</strong> — serverless COG tiling<br />
       <small>COG URL (EPSG:3857, or any projected/4326 - warped on the fly):</small>
-      <input id="url" value="./sample-3857-cog.tif" placeholder="https://.../cog-3857.tif" />
+      <input id="url" value="https://data.source.coop/giswqs/opengeos/dem.tif" placeholder="https://.../cog-3857.tif" />
       <div>
         rescale
         <input
@@ -56,7 +56,7 @@
           type="number"
           value="0"
           style="width: 70px"
-        />–<input id="max" type="number" value="1100" style="width: 70px" />
+        />–<input id="max" type="number" value="1600" style="width: 70px" />
         <select id="cmap">
           <option selected>terrain</option>
           <option>viridis</option>


### PR DESCRIPTION
Prefill the demo with `https://data.source.coop/giswqs/opengeos/dem.tif` (a real EPSG:3857 DEM served with HTTP range + CORS) instead of the bundled synthetic sample, and bump the rescale max to 1600 for its ~60-1565 m range.

Demonstrates remote COG streaming on first visit. Verified in a browser: auto-loads and renders (EPSG:3857, 3 levels), terrain colormap, fit to bounds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated demo default data source to an external COG URL
  * Improved rescale control layout with inline min/max input fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->