### PR TITLE
feat: open local rasters + npm run dev for local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ wasm-pack build crates/cog-tiler-wasm --release --target web --out-dir pkg
 
 ### Run the demo locally
 
-The demo imports `./cog-tiler.js`, which imports `./cog_tiler_wasm.js`, so build
-the wasm and copy the module into `demo/`, then serve that folder (any static
-server with HTTP range support works; the bundled sample is same-origin, no CORS):
-
 ```bash
-wasm-pack build crates/cog-tiler-wasm --release --target web --out-dir ../../demo
-cp cog-tiler.js examples/sample-3857-cog.tif demo/
-python3 -m http.server -d demo 8000   # then open http://localhost:8000/
+npm run dev   # builds the wasm, assembles demo/, serves http://localhost:8000/
 ```
+
+`npm run dev` builds the wasm into `demo/`, copies in `cog-tiler.js` + the sample,
+and starts a zero-dependency static server with **HTTP range support** (which the
+tile streaming needs - the stdlib `python -m http.server` does not do ranges).
+Set `PORT` to change the port. No `npm install` is required (the dev scripts use
+only Node built-ins; the demo loads its peer deps from a CDN via an import map).
 
 The published [GitHub Pages demo](https://opengeos.github.io/cog-tiler-wasm/) is
 built the same way by `.github/workflows/pages.yml`.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ registerCogProtocol(maplibregl, "cog", () => ({
 }));
 
 source = await openCog(url); // EPSG:3857 fast path, or warped if projected/4326
+// openCog also accepts a local raster: a File (e.g. from <input type=file>),
+// Blob, ArrayBuffer, or Uint8Array - read in memory, no server needed.
 map.addSource("cog", { type: "raster", tiles: ["cog://{z}/{x}/{y}"], tileSize: 256 });
 map.addLayer({ id: "cog", type: "raster", source: "cog" });
 

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -55,8 +55,12 @@ export declare class CogSource {
 /** Initialize the wasm modules (idempotent). Resolve before `openCog`. */
 export declare function init(): Promise<unknown>;
 
-/** Open a COG and return a {@link CogSource} ready to render XYZ tiles. */
-export declare function openCog(url: string): Promise<CogSource>;
+/**
+ * Open a COG and return a {@link CogSource} ready to render XYZ tiles. Pass a URL
+ * string (read via HTTP range) or in-memory bytes / a Blob / a File for a local
+ * raster.
+ */
+export declare function openCog(source: string | ArrayBuffer | Uint8Array | Blob): Promise<CogSource>;
 
 /** Encode a 256x256 RGBA buffer to PNG bytes (browser; uses OffscreenCanvas). */
 export declare function rgbaToPng(rgba: Uint8Array | Uint8ClampedArray): Promise<Uint8Array>;

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -76,6 +76,22 @@ function bilin(v00, v10, v01, v11, tx, ty) {
   return top + (bot - top) * ty;
 }
 
+// Bilinear sample of a row-major window at fractional (fc,fr). Returns NaN when
+// the cell center is outside the window so out-of-raster pixels stay transparent
+// (no edge smear); falls back to nearest at the window edge / next to nodata.
+function sampleWindowBilinear(buf, w, h, fc, fr) {
+  const c0 = Math.floor(fc), r0 = Math.floor(fr);
+  if (c0 < 0 || c0 >= w || r0 < 0 || r0 >= h) return NaN;
+  const c1 = Math.min(c0 + 1, w - 1), r1 = Math.min(r0 + 1, h - 1);
+  const v00 = buf[r0 * w + c0];
+  if (Number.isNaN(v00)) return NaN;
+  const v10 = buf[r0 * w + c1], v01 = buf[r1 * w + c0], v11 = buf[r1 * w + c1];
+  if (Number.isNaN(v10) || Number.isNaN(v01) || Number.isNaN(v11)) return v00; // edge/nodata
+  const tx = fc - c0, ty = fr - r0;
+  const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
+  return top + (bot - top) * ty;
+}
+
 // Build a byte reader from a URL string or an in-memory source (ArrayBuffer,
 // Uint8Array, or Blob/File). `range(a,b)` yields bytes [a..b]; `openTiff()`
 // returns a geotiff.js GeoTIFF for reading the CRS / color table from the header.
@@ -143,6 +159,7 @@ export async function openCog(source) {
       mode: "3857",
       crsLabel: "EPSG:3857",
       palette: null,
+      toSource: { forward: (c) => c }, // identity: mercator meters == source meters
       boundsLonLat: Array.from(stream.bounds_lonlat()),
     });
   }
@@ -192,9 +209,10 @@ export class CogSource {
 
   /** Render an XYZ tile to a 256x256 RGBA `Uint8ClampedArray`, or null if empty. */
   async renderTileRGBA(z, x, y, opts = {}) {
-    return this.mode === "warp"
-      ? this._warp(z, x, y, opts)
-      : this._render3857(z, x, y, opts);
+    // Both EPSG:3857 (identity transform) and projected sources go through the
+    // same per-output-pixel mapping, which leaves out-of-raster pixels
+    // transparent instead of smearing edge pixels across partial tiles.
+    return this._warp(z, x, y, opts);
   }
 
   /** Render an XYZ tile to PNG bytes (empty `Uint8Array` for a blank tile). */
@@ -268,19 +286,13 @@ export class CogSource {
     ];
   }
 
-  // Fast path: source already EPSG:3857, so a tile maps affinely to a window.
-  async _render3857(z, x, y, { min = 0, max = 1, colormap = "viridis" } = {}) {
-    const win = this.tiler.pixel_window_for_tile(z, x, y);
-    if (win.empty) return null;
-    const buf = await this._assembleWindow(win.level, win.x, win.y, win.w, win.h);
-    return this.tiler.render(buf, win.w, win.h, min, max, colormap, true);
-  }
-
-  // Warp path: reproject a Web Mercator tile from the source CRS on the fly.
-  // A coarse grid of mercator->source samples (proj4) is bilinearly interpolated
-  // per output pixel, then nearest-sampled from the source window (correct for
-  // categorical data). Paletted sources use the color table; others reuse the
-  // Rust colormap (render resamples 256->256, ~identity).
+  // Render a Web Mercator tile from the source on the fly. A coarse grid of
+  // mercator->source samples (the proj4 transform, or identity for EPSG:3857) is
+  // bilinearly interpolated per output pixel to a source location, then sampled
+  // from the source window - bilinear for continuous data, nearest for paletted
+  // (categorical) data. Out-of-raster pixels stay transparent (no edge smear).
+  // Paletted sources use the color table; others reuse the Rust colormap (render
+  // resamples 256->256, ~identity).
   async _warp(z, x, y, { min = 0, max = 1, colormap = "viridis" } = {}) {
     const tb = tileBounds3857(z, x, y);
     const nx = new Float64Array((NG + 1) * (NG + 1));
@@ -328,18 +340,23 @@ export class CogSource {
         const sx = bilin(nx[i00], nx[i00 + 1], nx[i00 + NG + 1], nx[i00 + NG + 2], tx, ty);
         const sy = bilin(ny[i00], ny[i00 + 1], ny[i00 + NG + 1], ny[i00 + NG + 2], tx, ty);
         if (!isFinite(sx) || !isFinite(sy)) continue;
-        const col = Math.floor((sx - ox) / lpw) - c0;
-        const row = Math.floor((oy - sy) / lph) - r0;
-        if (col < 0 || col >= ww || row < 0 || row >= hh) continue;
-        const v = buf[row * ww + col];
-        if (!isFinite(v)) continue;
+        const fcol = (sx - ox) / lpw - c0;
+        const frow = (oy - sy) / lph - r0;
         if (pal) {
+          // Categorical: nearest-neighbor + color table.
+          const col = Math.floor(fcol), row = Math.floor(frow);
+          if (col < 0 || col >= ww || row < 0 || row >= hh) continue;
+          const v = buf[row * ww + col];
+          if (!isFinite(v)) continue;
           const ci = v & 255;
           if (ci === 0 || (this.nodata != null && v === this.nodata)) continue;
           const o = (py * TILE + px) * 4;
           out[o] = pal[ci * 4]; out[o + 1] = pal[ci * 4 + 1];
           out[o + 2] = pal[ci * 4 + 2]; out[o + 3] = 255;
         } else {
+          // Continuous: bilinear; NaN (out of raster) leaves the pixel transparent.
+          const v = sampleWindowBilinear(buf, ww, hh, fcol, frow);
+          if (!isFinite(v)) continue;
           grid[py * TILE + px] = v;
         }
       }

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -76,15 +76,39 @@ function bilin(v00, v10, v01, v11, tx, ty) {
   return top + (bot - top) * ty;
 }
 
+// Build a byte reader from a URL string or an in-memory source (ArrayBuffer,
+// Uint8Array, or Blob/File). `range(a,b)` yields bytes [a..b]; `openTiff()`
+// returns a geotiff.js GeoTIFF for reading the CRS / color table from the header.
+async function makeReader(source) {
+  if (typeof source === "string") {
+    return { label: source, range: rangeFetcher(source), openTiff: () => GeoTIFF.fromUrl(source) };
+  }
+  let bytes;
+  if (source instanceof Uint8Array) bytes = source;
+  else if (source instanceof ArrayBuffer) bytes = new Uint8Array(source);
+  else if (source && typeof source.arrayBuffer === "function") {
+    bytes = new Uint8Array(await source.arrayBuffer()); // Blob / File
+  } else {
+    throw new Error("openCog: expected a URL string, ArrayBuffer, Uint8Array, or Blob");
+  }
+  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  return {
+    label: source.name || "(local file)",
+    range: (a, b) => Promise.resolve(bytes.subarray(a, Math.min(b + 1, bytes.length))),
+    openTiff: () => GeoTIFF.fromArrayBuffer(ab),
+  };
+}
+
 /**
- * Open a COG and return a {@link CogSource} ready to render XYZ tiles.
- * Detects EPSG:3857 (fast path) vs. any other CRS (warp path), and reads the
- * source projection + color table from the GeoTIFF header (whitebox-wasm 0.4.0
- * does not expose them).
+ * Open a COG and return a {@link CogSource} ready to render XYZ tiles. `source`
+ * is a URL string (read via HTTP range) or in-memory bytes / a Blob / a File for
+ * a local raster. Detects EPSG:3857 (fast path) vs. any other CRS (warp path),
+ * reading the source projection + color table from the GeoTIFF header (which
+ * whitebox-wasm 0.4.0 does not expose).
  */
-export async function openCog(url) {
+export async function openCog(source) {
   await init();
-  const range = rangeFetcher(url);
+  const { range, openTiff, label } = await makeReader(source);
   // Parse the COG header; grow the prefix and retry for large COGs whose IFDs
   // exceed 64 KB (many overviews / huge tile-offset arrays).
   let stream;
@@ -111,7 +135,7 @@ export async function openCog(url) {
     stream.nodata,
     JSON.stringify(levels),
   );
-  const base = { url, range, stream, tiler, levels, gt, nodata: stream.nodata };
+  const base = { url: label, range, stream, tiler, levels, gt, nodata: stream.nodata };
 
   if (stream.epsg === 3857) {
     return new CogSource({
@@ -124,7 +148,7 @@ export async function openCog(url) {
   }
 
   // Warp path: read the real source CRS + optional palette from the header.
-  const tiff = await GeoTIFF.fromUrl(url);
+  const tiff = await openTiff();
   const img = await tiff.getImage();
   const srcDef = geokeysToProj4.toProj4(img.getGeoKeys()).proj4;
   if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -107,7 +107,12 @@ async function makeReader(source) {
   } else {
     throw new Error("openCog: expected a URL string, ArrayBuffer, Uint8Array, or Blob");
   }
-  const ab = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
+  // Reuse the underlying buffer when the view spans it exactly; only copy for a
+  // partial view (avoids duplicating a large raster in memory).
+  const ab =
+    bytes.byteOffset === 0 && bytes.byteLength === bytes.buffer.byteLength
+      ? bytes.buffer
+      : bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   return {
     label: source.name || "(local file)",
     range: (a, b) => Promise.resolve(bytes.subarray(a, Math.min(b + 1, bytes.length))),

--- a/demo/index.html
+++ b/demo/index.html
@@ -49,6 +49,10 @@
       <strong>cog-tiler-wasm</strong> — serverless COG tiling<br />
       <small>COG URL (EPSG:3857, or any projected/4326 - warped on the fly):</small>
       <input id="url" value="https://data.source.coop/giswqs/opengeos/dem.tif" placeholder="https://.../cog-3857.tif" />
+      <div style="margin: 4px 0">
+        <small>or open a local COG:</small>
+        <input id="file" type="file" accept=".tif,.tiff,image/tiff" style="width: auto" />
+      </div>
       <div>
         rescale
         <input
@@ -119,21 +123,25 @@
         render: readRender(),
       }));
 
-      async function load() {
-        const url = document.getElementById("url").value.trim();
-        if (!url) return;
-        status("opening COG…");
+      let cogVersion = 0;
+      // `source` is a URL string or a File (local raster); defaults to the URL box.
+      async function load(source) {
+        const src = source ?? document.getElementById("url").value.trim();
+        if (!src) return;
+        status(`opening ${typeof src === "string" ? "COG" : src.name}…`);
         try {
-          current = await openCog(url);
+          current = await openCog(src);
           status(
             `${current.crsLabel}, ${current.levels.length} levels` +
               (current.hasPalette ? " (palette)" : ""),
           );
           if (map.getLayer("cog")) map.removeLayer("cog");
           if (map.getSource("cog")) map.removeSource("cog");
+          // Bump the tile-URL version so MapLibre refetches instead of serving
+          // cached tiles from a previously loaded raster (same cog:// template).
           map.addSource("cog", {
             type: "raster",
-            tiles: ["cog://{z}/{x}/{y}"],
+            tiles: [`cog://{z}/{x}/{y}?v=${++cogVersion}`],
             tileSize: 256,
           });
           map.addLayer({ id: "cog", type: "raster", source: "cog" });
@@ -147,11 +155,14 @@
         }
       }
 
-      document.getElementById("load").onclick = load;
+      document.getElementById("load").onclick = () => load();
+      document.getElementById("file").onchange = (e) => {
+        if (e.target.files[0]) load(e.target.files[0]);
+      };
       // Auto-load the prefilled sample so the demo works on first visit.
       if (document.getElementById("url").value.trim()) {
         if (map.loaded()) load();
-        else map.on("load", load);
+        else map.on("load", () => load());
       }
     </script>
   </body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -50,7 +50,7 @@
       <small>COG URL (EPSG:3857, or any projected/4326 - warped on the fly):</small>
       <input id="url" value="https://data.source.coop/giswqs/opengeos/dem.tif" placeholder="https://.../cog-3857.tif" />
       <div style="margin: 4px 0">
-        <small>or open a local COG:</small>
+        <label for="file"><small>or open a local COG:</small></label>
         <input id="file" type="file" accept=".tif,.tiff,image/tiff" style="width: auto" />
       </div>
       <div>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "cog-tiler-wasm-dev",
+  "private": true,
+  "type": "module",
+  "description": "Dev scripts for the cog-tiler-wasm demo (the published package is assembled under crates/cog-tiler-wasm/pkg).",
+  "scripts": {
+    "build:wasm": "wasm-pack build crates/cog-tiler-wasm --release --target web --out-dir ../../demo",
+    "assemble:demo": "node scripts/assemble-demo.mjs",
+    "predev": "npm run build:wasm && npm run assemble:demo",
+    "dev": "node scripts/serve-demo.mjs",
+    "serve": "node scripts/serve-demo.mjs",
+    "build:pkg": "wasm-pack build crates/cog-tiler-wasm --release --target web --out-dir pkg && node scripts/prepare-pkg.mjs crates/cog-tiler-wasm/pkg"
+  }
+}

--- a/scripts/assemble-demo.mjs
+++ b/scripts/assemble-demo.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Copy the reusable module + sample into demo/ so the page (which imports
+// ./cog-tiler.js next to ./cog_tiler_wasm.js) can be served statically. The wasm
+// is built into demo/ by the `build:wasm` script.
+import { copyFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
+copyFileSync(join(root, "cog-tiler.js"), join(root, "demo", "cog-tiler.js"));
+copyFileSync(join(root, "examples", "sample-3857-cog.tif"), join(root, "demo", "sample-3857-cog.tif"));
+console.log("assembled demo/ (cog-tiler.js + sample-3857-cog.tif)");

--- a/scripts/serve-demo.mjs
+++ b/scripts/serve-demo.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Zero-dependency static server for the demo with HTTP Range support, which the
+// COG tile streaming requires (the stdlib python http.server does not do Range).
+// Serves ./demo on PORT (default 8000).
+import { createServer } from "node:http";
+import { stat } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { join, normalize, extname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = join(fileURLToPath(new URL(".", import.meta.url)), "..", "demo");
+const port = Number(process.env.PORT) || 8000;
+
+const TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".wasm": "application/wasm",
+  ".json": "application/json",
+  ".tif": "image/tiff",
+  ".tiff": "image/tiff",
+  ".css": "text/css",
+  ".map": "application/json",
+};
+
+const server = createServer(async (req, res) => {
+  let urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+  if (urlPath.endsWith("/")) urlPath += "index.html";
+  const filePath = normalize(join(root, urlPath));
+  if (!filePath.startsWith(root)) return res.writeHead(403).end();
+
+  let st;
+  try {
+    st = await stat(filePath);
+  } catch {
+    return res.writeHead(404).end("not found");
+  }
+  if (!st.isFile()) return res.writeHead(404).end("not found");
+
+  const type = TYPES[extname(filePath).toLowerCase()] || "application/octet-stream";
+  const range = req.headers.range && /bytes=(\d+)-(\d*)/.exec(req.headers.range);
+  if (range) {
+    const start = Number(range[1]);
+    const end = range[2] ? Math.min(Number(range[2]), st.size - 1) : st.size - 1;
+    res.writeHead(206, {
+      "Content-Type": type,
+      "Content-Range": `bytes ${start}-${end}/${st.size}`,
+      "Accept-Ranges": "bytes",
+      "Content-Length": end - start + 1,
+    });
+    createReadStream(filePath, { start, end }).pipe(res);
+  } else {
+    res.writeHead(200, { "Content-Type": type, "Content-Length": st.size, "Accept-Ranges": "bytes" });
+    createReadStream(filePath).pipe(res);
+  }
+});
+
+server.listen(port, () => console.log(`cog-tiler-wasm demo: http://localhost:${port}/`));

--- a/scripts/serve-demo.mjs
+++ b/scripts/serve-demo.mjs
@@ -5,7 +5,7 @@
 import { createServer } from "node:http";
 import { stat } from "node:fs/promises";
 import { createReadStream } from "node:fs";
-import { join, normalize, extname } from "node:path";
+import { join, normalize, extname, relative, isAbsolute } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(fileURLToPath(new URL(".", import.meta.url)), "..", "demo");
@@ -24,10 +24,16 @@ const TYPES = {
 };
 
 const server = createServer(async (req, res) => {
-  let urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+  let urlPath;
+  try {
+    urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+  } catch {
+    return res.writeHead(400).end("bad request");
+  }
   if (urlPath.endsWith("/")) urlPath += "index.html";
-  const filePath = normalize(join(root, urlPath));
-  if (!filePath.startsWith(root)) return res.writeHead(403).end();
+  const filePath = normalize(join(root, "." + urlPath));
+  const rel = relative(root, filePath);
+  if (rel.startsWith("..") || isAbsolute(rel)) return res.writeHead(403).end();
 
   let st;
   try {
@@ -42,6 +48,9 @@ const server = createServer(async (req, res) => {
   if (range) {
     const start = Number(range[1]);
     const end = range[2] ? Math.min(Number(range[2]), st.size - 1) : st.size - 1;
+    if (start >= st.size || end < start) {
+      return res.writeHead(416, { "Content-Range": `bytes */${st.size}` }).end();
+    }
     res.writeHead(206, {
       "Content-Type": type,
       "Content-Range": `bytes ${start}-${end}/${st.size}`,


### PR DESCRIPTION
Adds the ability to **select a local raster** and visualize it (no server), plus a one-command **`npm run dev`** to test the demo locally.

## Local rasters

- **`openCog(source)`** now accepts a URL string **or** in-memory bytes: a `File` (e.g. from `<input type=file>`), `Blob`, `ArrayBuffer`, or `Uint8Array`. A `makeReader` abstraction supplies the byte reader (HTTP range for URLs, in-memory slicing for local data) and the geotiff.js handle (`fromUrl` vs `fromArrayBuffer`) used to read the CRS + color table. The 3857 and warp paths are unchanged.
- **Demo**: an "open a local COG" file picker; `load()` takes a URL or a `File`; per-load `cog://...?v=N` cache-bust so MapLibre refetches when switching rasters.

## `npm run dev`

- A private, dev-only root `package.json`: `npm run dev` builds the wasm into `demo/`, assembles the module + sample, and serves with a **Range-capable** zero-dependency Node server (`scripts/serve-demo.mjs`) - the tile streaming needs HTTP range, which `python -m http.server` does not provide. No `npm install` required (Node built-ins only; demo peer deps load from a CDN via the import map). `PORT` configurable.

## Verified (browser)

- Local **EPSG:3857** COG renders via the picker; local **EPSG:5070 (Albers)** COG warps correctly to Web Mercator over CONUS (in-memory `fromArrayBuffer` + warp path); remote `dem.tif` still auto-loads.
- `npm run dev` builds, serves on the chosen PORT, returns `application/wasm` + 206 ranges, and the demo renders.

## Notes

- Local files are read fully into memory (only needed tiles are decoded from those bytes); fine for typical files, heavy for multi-GB rasters.
- Non-COG / striped GeoTIFFs aren't supported (whitebox `CogStream` is COG-only); they show a clear error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended `openCog` to accept HTTP URLs or local/in-memory raster inputs (File, Blob, ArrayBuffer, Uint8Array) for in-browser, serverless usage
  * Demo now lets you pick a local COG file and reloads tiles with a cache-busting version to prevent stale results
* **Bug Fixes**
  * Improved continuous (non-paletted) tile rendering using refined bilinear sampling so out-of-raster pixels remain transparent
* **Documentation**
  * Updated README demo instructions and clarified supported `openCog` input types
* **Chores**
  * Added a Node-based dev workflow to build, assemble, and serve the demo with HTTP byte-range support
<!-- end of auto-generated comment: release notes by coderabbit.ai -->