### PR TITLE
feat: TiTiler-style read API (info, info.geojson, tilejson, point, statistics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,27 @@ map.addLayer({ id: "cog", type: "raster", source: "cog" });
 // and source.renderTileRGBA(z, x, y, render) / renderTilePNG(...) are also exposed.
 ```
 
+### TiTiler-style COG API
+
+`CogSource` mirrors the read endpoints of
+[TiTiler's COG API](https://developmentseed.org/titiler/endpoints/cog/),
+client-side (works on projected/paletted sources too, via the warp path):
+
+```js
+src.info();           // /cog/info     -> bounds, count, dtype, nodata, overviews, min/maxzoom, ...
+src.infoGeoJSON();    // /cog/info.geojson -> GeoJSON Feature (bbox polygon + info)
+src.tilejson();       // /cog/tilejson.json -> Mapbox TileJSON document
+await src.point(lon, lat);          // /cog/point -> band value(s) at a WGS84 coordinate
+await src.statistics({ maxSize });  // /cog/statistics -> per-band min/max/mean/std/
+                                    //   count/valid_percent/median/percentiles/histogram
+                                    //   (from a decimated overview)
+```
+
+Tile/image rendering, band selection (`bidx`/RGB), `preview`, and `bbox`/`part`
+are tracked in the [roadmap](#roadmap). Server-only endpoints (`/map.html`,
+`WMTSCapabilities.xml`, `/validate`, `/stac`) are out of scope for a client-side
+library.
+
 For a no-build page, map the peer deps with an import map (see
 [`demo/index.html`](demo/index.html)):
 
@@ -160,13 +181,15 @@ fully transparent.
 
 ## Roadmap
 
+- **TiTiler COG API parity** - done: `info`, `info.geojson`, `tilejson`,
+  `point`, `statistics` (see [above](#titiler-style-cog-api)). Next:
+  **`bidx`/RGB band selection**, more **colormaps**, and **`preview`** +
+  **`bbox`/`part`** image generation; later, band-math **expressions**.
 - **Warping** of projected/4326 sources and **paletted/categorical** rendering
   are done in [`cog-tiler.js`](cog-tiler.js) (proj4js + geotiff.js). Next: expose
   the source proj string + color table **upstream in `whitebox-wasm`** (it
   already parses both) to drop the geotiff.js dependency, then move the warp into
   the Rust crate (`proj4rs`).
-- **Multi-band / RGB** rendering and band-math expressions.
-- **More colormaps** and discrete/classified styling.
 - **Edge / WASI serving** - run the same module as a serverless XYZ endpoint
   near the data, not only in the browser.
 - **STAC / mosaics** - multi-asset orchestration.

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -50,6 +50,28 @@ export declare class CogSource {
   ): Promise<Uint8Array | Uint8ClampedArray | null>;
   /** Render an XYZ tile to PNG bytes (empty Uint8Array for a blank tile). */
   renderTilePNG(z: number, x: number, y: number, opts?: RenderOptions): Promise<Uint8Array>;
+
+  // TiTiler-style read API.
+
+  /** Dataset info (bounds, bands, dtype, nodata, overviews, min/maxzoom, ...). */
+  info(): Record<string, unknown>;
+  /** Dataset info as a GeoJSON Feature (bbox polygon + info properties). */
+  infoGeoJSON(): Record<string, unknown>;
+  /** Mapbox TileJSON document. */
+  tilejson(opts?: {
+    tilesUrl?: string;
+    minzoom?: number;
+    maxzoom?: number;
+    scheme?: string;
+  }): Record<string, unknown>;
+  /** Band value(s) at a WGS84 lon/lat. `bidx` is 1-based; default all bands. */
+  point(
+    lon: number,
+    lat: number,
+    opts?: { bidx?: number[] },
+  ): Promise<{ coordinates: [number, number]; values: number[]; band_names: string[]; outside?: boolean }>;
+  /** Per-band statistics from a decimated overview (≤ `maxSize` px wide). */
+  statistics(opts?: { maxSize?: number }): Promise<Record<string, Record<string, unknown>>>;
 }
 
 /** Initialize the wasm modules (idempotent). Resolve before `openCog`. */

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -54,6 +54,54 @@ const rangeFetcher = (url) => (a, b) =>
     .then((r) => r.arrayBuffer())
     .then((b) => new Uint8Array(b));
 
+/** Map a level descriptor's sample format + bit depth to a numpy-style dtype. */
+function dtypeOf(lv) {
+  const b = lv.bits_per_sample;
+  const f = (lv.sample_format || "").toLowerCase();
+  if (f.includes("float") || f.includes("ieee")) return "float" + b;
+  if (f === "uint" || f.includes("unsigned")) return "uint" + b;
+  if (f === "int" || f.includes("signed")) return "int" + b;
+  return (f || "uint") + b;
+}
+
+/** Min/max/mean/std/count/valid_percent/percentiles/histogram for a band buffer. */
+function computeStats(buf, nodata) {
+  let min = Infinity, max = -Infinity, sum = 0, sumsq = 0;
+  const valid = [];
+  for (let i = 0; i < buf.length; i++) {
+    const v = buf[i];
+    if (Number.isNaN(v)) continue;
+    if (nodata != null && v === nodata) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+    sumsq += v * v;
+    valid.push(v);
+  }
+  const count = valid.length;
+  if (count === 0) return { count: 0, valid_percent: 0 };
+  const mean = sum / count;
+  const std = Math.sqrt(Math.max(0, sumsq / count - mean * mean));
+  valid.sort((a, b) => a - b);
+  const pct = (p) => valid[Math.min(count - 1, Math.floor((p / 100) * count))];
+  const bins = 10, span = max - min || 1, hist = new Array(bins).fill(0);
+  for (const v of valid) {
+    let k = Math.floor(((v - min) / span) * bins);
+    if (k >= bins) k = bins - 1;
+    if (k < 0) k = 0;
+    hist[k]++;
+  }
+  const edges = Array.from({ length: bins + 1 }, (_, i) => min + (span * i) / bins);
+  return {
+    min, max, mean, std, count,
+    valid_percent: (count / buf.length) * 100,
+    median: pct(50),
+    percentile_2: pct(2),
+    percentile_98: pct(98),
+    histogram: [hist, edges],
+  };
+}
+
 /** Build a 256-entry RGBA palette from a TIFF ColorMap (16-bit R,G,B blocks). */
 function buildPalette(colorMap) {
   if (!colorMap) return null;
@@ -247,8 +295,9 @@ export class CogSource {
   }
 
   // Fetch (parallel, cached) + decode the source tiles covering a level pixel
-  // window and assemble them into a row-major f64 buffer (NaN = no data).
-  async _assembleWindow(level, x, y, w, h) {
+  // window and assemble band `band` (0-based) into a row-major f64 buffer
+  // (NaN = no data). decode_tile_f64 is pixel-interleaved, so stride by `bands`.
+  async _assembleWindow(level, x, y, w, h, band = 0) {
     const lv = this.levels[level];
     const tiles = JSON.parse(this.stream.tiles_for_window(level, x, y, w, h));
     const decoded = await Promise.all(tiles.map((t) => this._getTile(level, t)));
@@ -263,7 +312,7 @@ export class CogSource {
         for (let rx = 0; rx < tw; rx++) {
           const ox = tx0 + rx - x;
           if (ox < 0 || ox >= w) continue;
-          buf[oy * w + ox] = px[(ry * tw + rx) * bands]; // band 0
+          buf[oy * w + ox] = px[(ry * tw + rx) * bands + band];
         }
       }
     });
@@ -368,6 +417,111 @@ export class CogSource {
     }
     if (pal) return out;
     return this.tiler.render(grid, TILE, TILE, min, max, colormap, true);
+  }
+
+  // --- TiTiler-style read API ----------------------------------------------
+
+  /** XYZ zoom whose tile resolution matches the full-res pixel size. */
+  _maxzoom() {
+    const res = Math.abs(this.gt[1]);
+    return Math.max(0, Math.min(24, Math.round(Math.log2((2 * OS) / (TILE * res)))));
+  }
+
+  /** XYZ zoom whose tile resolution matches the coarsest overview. */
+  _minzoom() {
+    const c = this.levels[this.levels.length - 1];
+    const res = Math.abs(this.gt[1]) * (this.levels[0].width / c.width);
+    return Math.max(0, Math.min(24, Math.round(Math.log2((2 * OS) / (TILE * res)))));
+  }
+
+  /** Dataset info (≈ TiTiler `/cog/info`). */
+  info() {
+    const l0 = this.levels[0];
+    const b = this.boundsLonLat;
+    return {
+      bounds: b, // WGS84 [minlon, minlat, maxlon, maxlat]
+      crs: this.crsLabel,
+      width: l0.width,
+      height: l0.height,
+      count: l0.bands,
+      dtype: dtypeOf(l0),
+      nodata: this.nodata == null || Number.isNaN(this.nodata) ? null : this.nodata,
+      colorinterp: this.palette ? ["palette"] : null,
+      overviews: this.levels.length - 1,
+      tile_size: [l0.tile_width, l0.tile_height],
+      minzoom: this._minzoom(),
+      maxzoom: this._maxzoom(),
+      band_descriptions: Array.from({ length: l0.bands }, (_, i) => `b${i + 1}`),
+      compression: l0.compression,
+    };
+  }
+
+  /** Dataset info as a GeoJSON Feature (≈ TiTiler `/cog/info.geojson`). */
+  infoGeoJSON() {
+    const [w, s, e, n] = this.boundsLonLat;
+    return {
+      type: "Feature",
+      geometry: {
+        type: "Polygon",
+        coordinates: [[[w, s], [e, s], [e, n], [w, n], [w, s]]],
+      },
+      properties: this.info(),
+    };
+  }
+
+  /** Mapbox TileJSON document (≈ TiTiler `/cog/tilejson.json`). */
+  tilejson({ tilesUrl = "cog://{z}/{x}/{y}", minzoom, maxzoom, scheme = "xyz" } = {}) {
+    const b = this.boundsLonLat;
+    const mn = minzoom ?? this._minzoom();
+    return {
+      tilejson: "2.2.0",
+      version: "1.0.0",
+      scheme,
+      tiles: [tilesUrl],
+      minzoom: mn,
+      maxzoom: maxzoom ?? this._maxzoom(),
+      bounds: b,
+      center: [(b[0] + b[2]) / 2, (b[1] + b[3]) / 2, mn],
+    };
+  }
+
+  /** Band value(s) at a WGS84 lon/lat (≈ TiTiler `/cog/point/{lon},{lat}`). */
+  async point(lon, lat, { bidx } = {}) {
+    const [mx, my] = proj4("EPSG:4326", "EPSG:3857").forward([lon, lat]);
+    const [sx, sy] = this.toSource.forward([mx, my]); // source CRS coords
+    const l0 = this.levels[0];
+    const col = Math.floor((sx - this.gt[0]) / Math.abs(this.gt[1]));
+    const row = Math.floor((this.gt[3] - sy) / Math.abs(this.gt[5]));
+    if (col < 0 || col >= l0.width || row < 0 || row >= l0.height) {
+      return { coordinates: [lon, lat], values: [], band_names: [], outside: true };
+    }
+    const tcol = Math.floor(col / l0.tile_width), trow = Math.floor(row / l0.tile_height);
+    const [off, len] = Array.from(this.stream.tile_range(0, tcol, trow));
+    const px = await this._getTile(0, { col: tcol, row: trow, offset: off, length: len });
+    const base = ((row % l0.tile_height) * l0.tile_width + (col % l0.tile_width)) * l0.bands;
+    const bands = bidx ? bidx.map((b) => b - 1) : Array.from({ length: l0.bands }, (_, i) => i);
+    return {
+      coordinates: [lon, lat],
+      values: bands.map((b) => px[base + b]),
+      band_names: bands.map((b) => `b${b + 1}`),
+    };
+  }
+
+  /** Per-band statistics (≈ TiTiler `/cog/statistics`), from a decimated
+   *  overview (the largest one whose width is ≤ `maxSize`). */
+  async statistics({ maxSize = 1024 } = {}) {
+    let level = this.levels.length - 1;
+    for (let i = 0; i < this.levels.length; i++) {
+      if (this.levels[i].width <= maxSize) { level = i; break; }
+    }
+    const lv = this.levels[level];
+    const nodata = this.nodata == null || Number.isNaN(this.nodata) ? null : this.nodata;
+    const out = {};
+    for (let b = 0; b < lv.bands; b++) {
+      const buf = await this._assembleWindow(level, 0, 0, lv.width, lv.height, b);
+      out[`b${b + 1}`] = computeStats(buf, nodata);
+    }
+    return out;
   }
 }
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -159,6 +159,21 @@
       document.getElementById("file").onchange = (e) => {
         if (e.target.files[0]) load(e.target.files[0]);
       };
+      // Click the map to query the band value(s) at that point (TiTiler /point).
+      map.on("click", async (e) => {
+        if (!current) return;
+        try {
+          const p = await current.point(e.lngLat.lng, e.lngLat.lat);
+          const v = p.values.filter((x) => x != null && !Number.isNaN(x));
+          status(
+            v.length
+              ? `value: ${v.join(", ")} @ ${e.lngLat.lng.toFixed(4)}, ${e.lngLat.lat.toFixed(4)}`
+              : "no data at clicked point",
+          );
+        } catch (err) {
+          status("point error: " + err);
+        }
+      });
       // Auto-load the prefilled sample so the demo works on first visit.
       if (document.getElementById("url").value.trim()) {
         if (map.loaded()) load();


### PR DESCRIPTION
First of a few PRs bringing the package toward [TiTiler COG API](https://developmentseed.org/titiler/endpoints/cog/) parity. Since this is a client-side WASM library (no HTTP server), the endpoints become `CogSource` methods. This PR adds the **read/metadata** endpoints (all additive - no change to the render path; they work on projected/paletted sources via the warp path).

| TiTiler endpoint | Method |
|---|---|
| `/cog/info` | `src.info()` |
| `/cog/info.geojson` | `src.infoGeoJSON()` |
| `/cog/tilejson.json` | `src.tilejson()` |
| `/cog/point/{lon},{lat}` | `await src.point(lon, lat, {bidx})` |
| `/cog/statistics` | `await src.statistics({maxSize})` |

- **info / infoGeoJSON**: bounds, count, dtype, nodata, overviews, tile size, colorinterp, and min/maxzoom derived from the geotransform + overview resolutions.
- **tilejson**: bounds, center, min/maxzoom, tiles URL.
- **point**: lon/lat → mercator → source CRS → source pixel → reads one tile (works for 3857 and warped sources).
- **statistics**: per-band min/max/mean/std/count/valid_percent/median/percentile_2/percentile_98/histogram, from the largest overview ≤ maxSize (fast, approximate - like TiTiler's default).
- `_assembleWindow` gains a 0-based band index for multi-band reads.
- **demo**: click the map to query the band value at that point.

## Verified (browser, real data)

- `dem.tif`: `info.bounds` = Oregon, dtype float64, 2 overviews, minzoom 10 / maxzoom 12; `statistics` min/max ≈ 61/1524 (matches the DEM), valid_percent 28.6%, 10-bin histogram.
- `point`: a profile across the sample dome varies 540→933→535; **NLCD (warp) at (-100, 40) returns class 82 = Cultivated Crops** (correct for central-US cropland); click-to-point shows ~155 m at an Oregon pixel.

## Next (separate PRs)

`bidx`/RGB band selection + more colormaps, then `preview` + `bbox`/`part` image generation (need a render-engine refactor), then band-math `expression`. Server-only endpoints (`/map.html`, `WMTSCapabilities.xml`, `/validate`, `/stac`) are out of scope client-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dataset metadata APIs (info, GeoJSON, tile JSON).
  * Added per-band statistics computation from dataset overviews.
  * Map click handler now displays band values and coordinates at queried locations.

* **Documentation**
  * Documented TiTiler-style COG API endpoint parity.
  * Updated roadmap with completed items and revised planned work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->