### PR TITLE
feat: render curve (linear/sqrt/log), gamma, reverse colormap, opacity

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,14 +131,25 @@ await src.bboxPNG([minLon, minLat, maxLon, maxLat]);   // /cog/bbox    -> PNG by
 await src.preview(opts);   // -> { width, height, rgba }  (bbox() likewise)
 
 // Render params (on tiles, preview, bbox):
-//   bidx:    1-based bands; one -> colormap/palette, three -> RGB composite
-//   rescale: [[min,max], ...] per band, or [min,max]; or min/max shorthand
+//   bidx:     1-based bands; one -> colormap/palette, three -> RGB composite
+//   rescale:  [[min,max], ...] per band, or [min,max]; or min/max shorthand
 //   colormap: one of colormaps()  (viridis, magma, plasma, inferno, cividis,
 //             turbo, terrain, blues, greens, reds, rdylgn, spectral, gray)
-//   nodata:  override the transparency value
+//   reversed: sample the colormap back-to-front (single-band)
+//   stretch:  transfer curve "linear" | "sqrt" | "log"  (applied after rescale)
+//   gamma:    power-law gamma (1 = off; applied after the stretch)
+//   nodata:   override the transparency value
+//   opacity:  output alpha multiplier 0..1
 await src.renderTilePNG(z, x, y, { bidx: [4, 3, 2], rescale: [0, 3000] }); // false-color RGB
 import { colormaps } from "cog-tiler-wasm";
 ```
+
+The render pipeline (nodata -> rescale -> stretch -> gamma -> colormap, plus
+reverse/opacity) matches the controls of GPU raster viewers such as
+[maplibre-gl-raster](https://github.com/opengeos/maplibre-gl-raster), so
+`cog-tiler-wasm` can serve as a CPU/WASM rendering backend for the same UI - the
+panel (band, rescale, colormap, curve, gamma, opacity) maps directly onto these
+params and re-renders by re-requesting tiles.
 
 Server-only endpoints (`/map.html`, `WMTSCapabilities.xml`, `/validate`,
 `/stac`) are out of scope for a client-side library; band-math `expression` is

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -17,6 +17,15 @@ export interface RenderOptions {
   bidx?: number[];
   /** Override the source nodata value for transparency. */
   nodata?: number;
+  /** Transfer curve applied to the rescaled value before the colormap.
+   *  Default "linear". */
+  stretch?: "linear" | "sqrt" | "log";
+  /** Power-law gamma (1 = off). Applied after the stretch. */
+  gamma?: number;
+  /** Sample the colormap back-to-front (single-band). */
+  reversed?: boolean;
+  /** Output alpha multiplier in [0,1]. Default 1. */
+  opacity?: number;
 }
 
 /** A rendered image: row-major RGBA, `width * height * 4` bytes. */

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -102,6 +102,15 @@ function computeStats(buf, nodata) {
   };
 }
 
+/** Transfer curve for a rescaled value in 0..1: stretch then gamma (mirrors the
+ *  Rust `transfer`; reversal is colormap-only so it's not applied to RGB). */
+function transferCurve(t, stretch, gamma) {
+  if (stretch === "sqrt") t = Math.sqrt(t);
+  else if (stretch === "log") t = Math.log(1 + 99 * t) / Math.log(100);
+  if (gamma && gamma !== 1) t = Math.pow(t, 1 / Math.max(gamma, 1e-4));
+  return t;
+}
+
 /** Normalize render rescale options to a list of [min,max] pairs (per band). */
 function rescaleList(opts) {
   if (Array.isArray(opts.rescale) && opts.rescale.length) {
@@ -380,6 +389,12 @@ export class CogSource {
     const colormap = opts.colormap || "viridis";
     const nodata = opts.nodata != null ? opts.nodata : this.nodata;
     const ndSet = nodata != null && !Number.isNaN(nodata);
+    // Transfer-curve params (parity with maplibre-gl-raster's shader pipeline).
+    const stretch = opts.stretch || "linear";
+    const gamma = opts.gamma ?? 1;
+    const reversed = !!opts.reversed;
+    const opacity = opts.opacity ?? 1;
+    const alpha = Math.max(0, Math.min(255, Math.round(opacity * 255)));
 
     // Gridded mercator -> source samples, and the source-coord bbox they span.
     const nx = new Float64Array((NG + 1) * (NG + 1));
@@ -444,17 +459,18 @@ export class CogSource {
           // paletted convention that index 0 is the background/no-data class.
           if (ndSet ? v === nodata : ci === 0) continue;
           out[o] = pal[ci * 4]; out[o + 1] = pal[ci * 4 + 1];
-          out[o + 2] = pal[ci * 4 + 2]; out[o + 3] = 255;
+          out[o + 2] = pal[ci * 4 + 2]; out[o + 3] = alpha;
         } else if (rgb) {
-          // RGB composite: bilinear-sample each band, rescale to 0..255.
+          // RGB composite: bilinear-sample each band, rescale -> curve -> gamma.
           let ok = true;
           for (let k = 0; k < 3; k++) {
             const v = sampleWindowBilinear(bufs[k], ww, hh, fcol, frow);
             if (!isFinite(v) || (ndSet && v === nodata)) { ok = false; break; }
             const [mn, mx] = rescales[k] || rescales[0];
-            out[o + k] = Math.max(0, Math.min(255, ((v - mn) / ((mx - mn) || 1)) * 255));
+            const t = transferCurve(Math.max(0, Math.min(1, (v - mn) / ((mx - mn) || 1))), stretch, gamma);
+            out[o + k] = Math.round(t * 255);
           }
-          if (ok) out[o + 3] = 255;
+          if (ok) out[o + 3] = alpha;
           else { out[o] = out[o + 1] = out[o + 2] = 0; }
         } else {
           // Continuous single band: bilinear; colormap applied below.
@@ -469,7 +485,10 @@ export class CogSource {
     // colorize returns a Uint8Array; expose a Uint8ClampedArray (zero-copy view,
     // matching the palette/RGB branches and the RenderedImage type) so callers
     // can pass it straight to ImageData.
-    const c = colorize(grid, outW, outH, mn, mx, colormap, ndSet ? nodata : undefined, true);
+    const c = colorize(
+      grid, outW, outH, mn, mx, colormap, ndSet ? nodata : undefined, true,
+      stretch, gamma, reversed, opacity,
+    );
     return new Uint8ClampedArray(c.buffer, c.byteOffset, c.length);
   }
 

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -107,7 +107,7 @@ function computeStats(buf, nodata) {
 function transferCurve(t, stretch, gamma) {
   if (stretch === "sqrt") t = Math.sqrt(t);
   else if (stretch === "log") t = Math.log(1 + 99 * t) / Math.log(100);
-  if (gamma && gamma !== 1) t = Math.pow(t, 1 / Math.max(gamma, 1e-4));
+  if (Math.abs(gamma - 1) > 1e-9) t = Math.pow(t, 1 / Math.max(gamma, 1e-4));
   return t;
 }
 
@@ -390,11 +390,13 @@ export class CogSource {
     const nodata = opts.nodata != null ? opts.nodata : this.nodata;
     const ndSet = nodata != null && !Number.isNaN(nodata);
     // Transfer-curve params (parity with maplibre-gl-raster's shader pipeline).
+    // Normalize gamma/opacity here so the JS (RGB) and Rust (single-band) paths
+    // apply identical curves for the same options (e.g. gamma 0 -> clamped, not skipped).
     const stretch = opts.stretch || "linear";
-    const gamma = opts.gamma ?? 1;
+    const gamma = Number.isFinite(+opts.gamma) ? Math.max(+opts.gamma, 1e-4) : 1;
     const reversed = !!opts.reversed;
-    const opacity = opts.opacity ?? 1;
-    const alpha = Math.max(0, Math.min(255, Math.round(opacity * 255)));
+    const opacity = Number.isFinite(+opts.opacity) ? Math.max(0, Math.min(1, +opts.opacity)) : 1;
+    const alpha = Math.round(opacity * 255);
 
     // Gridded mercator -> source samples, and the source-coord bbox they span.
     const nx = new Float64Array((NG + 1) * (NG + 1));

--- a/crates/cog-tiler-wasm/src/lib.rs
+++ b/crates/cog-tiler-wasm/src/lib.rs
@@ -55,10 +55,32 @@ pub fn colormap_names() -> String {
     serde_json::to_string(colormap::NAMES).unwrap_or_else(|_| "[]".to_string())
 }
 
+/// Apply the rescaled value's transfer curve: stretch ("linear"|"sqrt"|"log"),
+/// then power-law gamma, then optional colormap reversal. Input/output in 0..1.
+/// Mirrors the maplibre-gl-raster shader order (rescale -> stretch -> gamma).
+fn transfer(mut t: f64, stretch: &str, gamma: f64, reversed: bool) -> f64 {
+    t = match stretch {
+        "sqrt" => t.sqrt(),
+        "log" => {
+            let k = 99.0; // maps 0->0, 1->1 with a log-ish lift of the low end
+            (1.0 + k * t).ln() / (1.0 + k).ln()
+        }
+        _ => t, // linear
+    };
+    if (gamma - 1.0).abs() > 1e-9 {
+        t = t.powf(1.0 / gamma.max(1e-4));
+    }
+    if reversed {
+        t = 1.0 - t;
+    }
+    t
+}
+
 /// Colormap a single-band `w*h` grid to RGBA at 1:1 (no resampling), for any
-/// output size. `NaN` (and the nodata value when `nodata_alpha`) become
-/// transparent. Pairs with the JS warp loop, which samples a grid at the output
-/// resolution; `render` (which always outputs 256x256) is the tile-only variant.
+/// output size, with rescale -> stretch -> gamma -> colormap (+ reverse) and a
+/// constant alpha from `opacity`. `NaN` (and the nodata value when
+/// `nodata_alpha`) become transparent. Pairs with the JS warp loop, which
+/// samples a grid at the output resolution.
 #[wasm_bindgen]
 #[allow(clippy::too_many_arguments)]
 pub fn colorize(
@@ -70,23 +92,28 @@ pub fn colorize(
     colormap: &str,
     nodata: Option<f64>,
     nodata_alpha: bool,
+    stretch: &str,
+    gamma: f64,
+    reversed: bool,
+    opacity: f64,
 ) -> Vec<u8> {
     let n = (width as usize) * (height as usize);
     let mut out = vec![0u8; n * 4];
     let range = max - min;
     let inv = if range != 0.0 { 1.0 / range } else { 0.0 };
     let nd = nodata.filter(|v| !v.is_nan());
+    let alpha = (opacity.clamp(0.0, 1.0) * 255.0).round() as u8;
     for (chunk, &v) in out.chunks_exact_mut(4).zip(pixels.iter()) {
         let is_nd = matches!(nd, Some(x) if v == x || (v - x).abs() <= f64::EPSILON);
         if v.is_nan() || (is_nd && nodata_alpha) {
             continue; // transparent
         }
-        let t = ((v - min) * inv).clamp(0.0, 1.0);
+        let t = transfer(((v - min) * inv).clamp(0.0, 1.0), stretch, gamma, reversed);
         let [r, g, b] = colormap::lookup(colormap, t);
         chunk[0] = r;
         chunk[1] = g;
         chunk[2] = b;
-        chunk[3] = 255;
+        chunk[3] = alpha;
     }
     out
 }

--- a/demo/index.html
+++ b/demo/index.html
@@ -62,6 +62,17 @@
           style="width: 70px"
         />–<input id="max" type="number" value="1600" style="width: 70px" />
         <select id="cmap"></select>
+        <label><input id="reversed" type="checkbox" style="width: auto" /> reverse</label>
+      </div>
+      <div style="margin: 4px 0">
+        curve
+        <select id="stretch" style="width: auto">
+          <option value="linear">linear</option>
+          <option value="sqrt">sqrt</option>
+          <option value="log">log</option>
+        </select>
+        gamma <input id="gamma" type="number" min="0.1" max="5" step="0.1" value="1" style="width: 56px" />
+        opacity <input id="opacity" type="number" min="0" max="1" step="0.1" value="1" style="width: 56px" />
         <button id="load">Load</button>
       </div>
       <small id="status"></small>
@@ -96,7 +107,15 @@
       const readRender = () => {
         let min = num("min", 0), max = num("max", 1);
         if (min >= max) max = min + 1; // avoid a zero/negative rescale range
-        return { min, max, colormap: document.getElementById("cmap").value };
+        return {
+          min,
+          max,
+          colormap: document.getElementById("cmap").value,
+          reversed: document.getElementById("reversed").checked,
+          stretch: document.getElementById("stretch").value,
+          gamma: num("gamma", 1),
+          opacity: num("opacity", 1),
+        };
       };
 
       const map = new maplibregl.Map({
@@ -141,16 +160,7 @@
             `${current.crsLabel}, ${current.levels.length} levels` +
               (current.hasPalette ? " (palette)" : ""),
           );
-          if (map.getLayer("cog")) map.removeLayer("cog");
-          if (map.getSource("cog")) map.removeSource("cog");
-          // Bump the tile-URL version so MapLibre refetches instead of serving
-          // cached tiles from a previously loaded raster (same cog:// template).
-          map.addSource("cog", {
-            type: "raster",
-            tiles: [`cog://{z}/{x}/{y}?v=${++cogVersion}`],
-            tileSize: 256,
-          });
-          map.addLayer({ id: "cog", type: "raster", source: "cog" });
+          restyle();
           // Zoom to the data: boundsLonLat = [minlon,minlat,maxlon,maxlat].
           const b = current.boundsLonLat;
           if (b && b.length === 4 && b.every(Number.isFinite)) {
@@ -161,10 +171,30 @@
         }
       }
 
+      // Re-render the active layer (e.g. after a panel control changes). Bumps
+      // the tile-URL version so MapLibre refetches with the current settings
+      // instead of serving cached tiles.
+      function restyle() {
+        if (!current) return;
+        if (map.getLayer("cog")) map.removeLayer("cog");
+        if (map.getSource("cog")) map.removeSource("cog");
+        map.addSource("cog", {
+          type: "raster",
+          tiles: [`cog://{z}/{x}/{y}?v=${++cogVersion}`],
+          tileSize: 256,
+        });
+        map.addLayer({ id: "cog", type: "raster", source: "cog" });
+      }
+
       document.getElementById("load").onclick = () => load();
       document.getElementById("file").onchange = (e) => {
         if (e.target.files[0]) load(e.target.files[0]);
       };
+      // Changing any render control re-renders the raster through cog-tiler-wasm.
+      for (const id of ["min", "max", "cmap", "reversed", "stretch", "gamma", "opacity"]) {
+        const el = document.getElementById(id);
+        el.addEventListener(el.tagName === "SELECT" || el.type === "checkbox" ? "change" : "input", restyle);
+      }
       // Click the map to query the band value(s) at that point (TiTiler /point).
       map.on("click", async (e) => {
         if (!current) return;

--- a/demo/index.html
+++ b/demo/index.html
@@ -71,8 +71,10 @@
           <option value="sqrt">sqrt</option>
           <option value="log">log</option>
         </select>
-        gamma <input id="gamma" type="number" min="0.1" max="5" step="0.1" value="1" style="width: 56px" />
-        opacity <input id="opacity" type="number" min="0" max="1" step="0.1" value="1" style="width: 56px" />
+        <label for="gamma">gamma</label>
+        <input id="gamma" type="number" min="0.1" max="5" step="0.1" value="1" style="width: 56px" />
+        <label for="opacity">opacity</label>
+        <input id="opacity" type="number" min="0" max="1" step="0.1" value="1" style="width: 56px" />
         <button id="load">Load</button>
       </div>
       <small id="status"></small>


### PR DESCRIPTION
Adds the remaining render controls so **cog-tiler-wasm can be the rendering engine** behind a GPU-style raster panel like [maplibre-gl-raster](https://github.com/opengeos/maplibre-gl-raster). band / rescale / colormap were already supported; this adds the rest, with math that **matches that project's shaders** so output is consistent.

Pipeline order: **nodata → rescale → stretch → gamma → colormap** (+ reverse, opacity).

## New render params (tiles, preview, bbox)

- **stretch** (curve): `"linear" | "sqrt" | "log"` — `sqrt(t)`; `ln(1+99t)/ln(100)`.
- **gamma**: `t^(1/gamma)` (1 = off).
- **reversed**: sample the colormap back-to-front (`lookup(1-t)`).
- **opacity**: scales output alpha.

## Where

- Rust `colorize()`: new params via a shared `transfer()` helper (single-band).
- JS `_renderExtent`: passes them through for single-band; applies stretch/gamma per channel for RGB and opacity on all paths (palette included).
- d.ts + README updated.
- **demo**: the panel now has reverse / curve / gamma / opacity controls, and changing any control live re-renders the raster through the engine - mirroring the maplibre-gl-raster "Add Raster Layer" panel.

## Verified (browser)

For a gray pixel at t=0.816: linear=208, sqrt=230, log=244, gamma2=230, reversed=47, opacity 0.5 → alpha 128 — all matching the formulas exactly. Demo re-renders live (dem.tif in turbo + log + reversed shown). Rust clippy/fmt clean.

## Note on integration

This completes the **package-side** parity (the panel's controls all map onto these params). Wiring an "engine: cog-tiler-wasm" selector into maplibre-gl-raster itself is consumer-side work in that repo (it would add a MapLibre raster source backed by `renderTilePNG` with the current panel settings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added render controls for `stretch` (linear/sqrt/log), `gamma`, `reversed`, and `opacity`, affecting how tiles are colorized and composited.
  * Demo UI now exposes these controls and applies them live by reloading tiles with the updated render settings.

* **Documentation**
  * Expanded TiTiler-style COG API documentation to include the new render parameters and the render pipeline order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->