### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cog-tiler-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/opengeos/cog-tiler-wasm"


### PR DESCRIPTION
Minor release. Since 0.1.0, this adds the TiTiler-style COG API and render controls:

- **Read API**: `info`, `info.geojson`, `tilejson`, `point`, `statistics`.
- **Image generation**: `preview` / `bbox` (+ PNG variants) at arbitrary sizes.
- **Rendering**: `bidx`/RGB band selection, 13 colormaps, and curve (linear/sqrt/log), gamma, reverse, opacity - matching maplibre-gl-raster's pipeline so the package can drive that panel.
- **Inputs**: open local rasters (File/Blob/bytes), not just URLs.
- **Fixes**: edge-smear elimination (per-pixel inverse mapping), pinned CogStream shapes, MapLibre import fix.
- **Tooling**: `npm run dev`, GitHub Pages demo.

Bumps the workspace version to 0.2.0. Merging then tagging `v0.2.0` triggers the release workflow (npm publish via Trusted Publishing + GitHub Release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->