### PR TITLE
fix: render planar (INTERLEAVE=BAND) multi-band COGs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,10 +210,12 @@ fully transparent.
   colormaps (see [above](#titiler-style-cog-api)). Next: band-math
   **`expression`** and `color_formula`.
 - **Warping** of projected/4326 sources and **paletted/categorical** rendering
-  are done in [`cog-tiler.js`](cog-tiler.js) (proj4js + geotiff.js). Next: expose
-  the source proj string + color table **upstream in `whitebox-wasm`** (it
-  already parses both) to drop the geotiff.js dependency, then move the warp into
-  the Rust crate (`proj4rs`).
+  are done in [`cog-tiler.js`](cog-tiler.js) (proj4js + geotiff.js). **Planar**
+  (`INTERLEAVE=BAND`) multi-band COGs are read per-band via geotiff.js too, since
+  whitebox-wasm's streaming decoder is chunky-only. Next: planar support
+  **upstream in `whitebox-wasm`** (and exposing its proj string + color table) to
+  drop the geotiff.js dependency, then move the warp into the Rust crate
+  (`proj4rs`).
 - **Edge / WASI serving** - run the same module as a serverless XYZ endpoint
   near the data, not only in the browser.
 - **STAC / mosaics** - multi-asset orchestration.

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -239,7 +239,18 @@ export async function openCog(source) {
   if (!Array.isArray(levels) || levels.length === 0) {
     throw new Error("levels_json() returned no levels");
   }
-  const base = { url: label, range, stream, levels, gt, nodata: stream.nodata };
+  // Open the GeoTIFF with geotiff.js when we need the CRS (non-3857) or to check
+  // the planar config (multi-band). whitebox-wasm's streaming decoder is
+  // chunky-only, so planar (INTERLEAVE=BAND) multi-band COGs are read per-band
+  // through geotiff.js instead (see _assembleWindow / point).
+  const multiBand = levels[0].bands > 1;
+  let tiff = null, img = null, planar = false;
+  if (stream.epsg !== 3857 || multiBand) {
+    tiff = await openTiff();
+    img = await tiff.getImage();
+    planar = multiBand && img.fileDirectory.PlanarConfiguration === 2;
+  }
+  const base = { url: label, range, stream, levels, gt, nodata: stream.nodata, tiff, planar };
 
   if (stream.epsg === 3857) {
     return new CogSource({
@@ -253,8 +264,6 @@ export async function openCog(source) {
   }
 
   // Warp path: read the real source CRS + optional palette from the header.
-  const tiff = await openTiff();
-  const img = await tiff.getImage();
   const srcDef = geokeysToProj4.toProj4(img.getGeoKeys()).proj4;
   if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");
   const toSource = proj4("EPSG:3857", srcDef); // forward: mercator -> source
@@ -326,10 +335,27 @@ export class CogSource {
     return p;
   }
 
-  // Fetch (parallel, cached) + decode the source tiles covering a level pixel
-  // window and assemble band `band` (0-based) into a row-major f64 buffer
-  // (NaN = no data). decode_tile_f64 is pixel-interleaved, so stride by `bands`.
+  /** geotiff.js image for an overview level (cached). Used for planar reads. */
+  _tiffImage(level) {
+    if (!this._imgs) this._imgs = new Map();
+    let p = this._imgs.get(level);
+    if (!p) {
+      p = this.tiff.getImage(level);
+      this._imgs.set(level, p);
+    }
+    return p;
+  }
+
+  // Fetch + decode band `band` (0-based) over a level pixel window into a
+  // row-major buffer. Chunky COGs go through whitebox (cached, NaN for gaps);
+  // planar (INTERLEAVE=BAND) COGs are read per-band via geotiff.js, which
+  // whitebox's chunky-only streaming decoder can't address.
   async _assembleWindow(level, x, y, w, h, band = 0) {
+    if (this.planar) {
+      const img = await this._tiffImage(level);
+      const rasters = await img.readRasters({ window: [x, y, x + w, y + h], samples: [band] });
+      return rasters[0]; // typed array, length w*h, row-major
+    }
     const lv = this.levels[level];
     const tiles = JSON.parse(this.stream.tiles_for_window(level, x, y, w, h));
     const decoded = await Promise.all(tiles.map((t) => this._getTile(level, t)));
@@ -570,14 +596,23 @@ export class CogSource {
     if (col < 0 || col >= l0.width || row < 0 || row >= l0.height) {
       return { coordinates: [lon, lat], values: [], band_names: [], outside: true };
     }
-    const tcol = Math.floor(col / l0.tile_width), trow = Math.floor(row / l0.tile_height);
-    const [off, len] = Array.from(this.stream.tile_range(0, tcol, trow));
-    const px = await this._getTile(0, { col: tcol, row: trow, offset: off, length: len });
-    const base = ((row % l0.tile_height) * l0.tile_width + (col % l0.tile_width)) * l0.bands;
     const bands = bidx ? bidx.map((b) => b - 1) : Array.from({ length: l0.bands }, (_, i) => i);
+    let values;
+    if (this.planar) {
+      // Planar: whitebox can't address bands 1..n; read the pixel via geotiff.js.
+      const img = await this._tiffImage(0);
+      const r = await img.readRasters({ window: [col, row, col + 1, row + 1], samples: bands });
+      values = r.map((b) => b[0]);
+    } else {
+      const tcol = Math.floor(col / l0.tile_width), trow = Math.floor(row / l0.tile_height);
+      const [off, len] = Array.from(this.stream.tile_range(0, tcol, trow));
+      const px = await this._getTile(0, { col: tcol, row: trow, offset: off, length: len });
+      const base = ((row % l0.tile_height) * l0.tile_width + (col % l0.tile_width)) * l0.bands;
+      values = bands.map((b) => px[base + b]);
+    }
     return {
       coordinates: [lon, lat],
-      values: bands.map((b) => px[base + b]),
+      values,
       band_names: bands.map((b) => `b${b + 1}`),
     };
   }


### PR DESCRIPTION
## Bug

`https://data.source.coop/giswqs/opengeos/landsat_ts/1984.tif` rendered as striped garbage with black bands.

## Cause

It's a **planar** COG (`INTERLEAVE=BAND`, 3 Byte bands, nodata=0). whitebox-wasm's streaming decoder is **chunky-only**: `tile_range(col,row)` indexes `row*tiles_x+col` (band 0's plane only), and `decode_tile_f64` returns a single band's tile. Confirmed empirically: `bands:3` but `decode_len:65536` (one band, not 196608) - so multi-band striding read the wrong layout.

## Fix (cog-tiler-only)

Read planar sources **per-band via geotiff.js** (already a dependency, handles both layouts); chunky COGs stay on the fast whitebox path.

- `openCog`: open the GeoTIFF once when the CRS is needed (non-3857) **or** the source is multi-band; `planar = PlanarConfiguration === 2 && bands > 1`.
- `_assembleWindow`: planar -> `img.readRasters({window, samples:[band]})` (per-level image cache); chunky unchanged.
- `point()`: planar -> read all bands at the pixel via `readRasters`.

## Verified (browser)

- **1984.tif** now renders as a clean **RGB composite** (Ucayali river + forest, no stripes); preview 100% colorful; `point` returns `[38, 83, 11]` for 3 bands.
- Regression: single-band **dem** (`planar:false`, chunky path) and paletted **NLCD** unaffected.

## Note

The proper long-term fix is planar support in whitebox-wasm's streaming reader (tracked in the roadmap); this keeps it self-contained using the existing geotiff.js dep.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated roadmap to clarify multi-band COG handling strategy and outline future optimization plans.

* **Improvements**
  * Enhanced support for multi-band Cloud Optimized GeoTIFFs with planar interleave format.
  * Optimized COG processing based on coordinate system and band structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->