### PR TITLE
chore(release): v0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cog-tiler-wasm"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cog-tiler-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/opengeos/cog-tiler-wasm"


### PR DESCRIPTION
Patch release. Since v0.2.0:

- **fix**: render planar (`INTERLEAVE=BAND`) multi-band COGs via geotiff.js (#14) - Landsat-style composites no longer render as stripes.
- **feat(demo)**: band selector (`bidx`) in the panel (#15).

Bumps the workspace version to 0.2.1 and refreshes `Cargo.lock` (it was stale at 0.1.0). Merging then tagging `v0.2.1` triggers the release workflow (npm publish + GitHub Release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->