### PR TITLE
fix(deps): accept geotiff v3 in peer range (0.2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cog-tiler-wasm"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cog-tiler-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/opengeos/cog-tiler-wasm"

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ For a no-build page, map the peer deps with an import map (see
   { "imports": {
     "whitebox-wasm": "https://esm.sh/whitebox-wasm@0.4.0",
     "proj4": "https://esm.sh/proj4@2.20.9",
-    "geotiff": "https://esm.sh/geotiff@2.1.3",
+    "geotiff": "https://esm.sh/geotiff@3.0.5",
     "geotiff-geokeys-to-proj4": "https://esm.sh/geotiff-geokeys-to-proj4@2024.4.13"
   } }
 </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -15,7 +15,7 @@
         "imports": {
           "whitebox-wasm": "https://esm.sh/whitebox-wasm@0.4.0",
           "proj4": "https://esm.sh/proj4@2.20.9",
-          "geotiff": "https://esm.sh/geotiff@2.1.3",
+          "geotiff": "https://esm.sh/geotiff@3.0.5",
           "geotiff-geokeys-to-proj4": "https://esm.sh/geotiff-geokeys-to-proj4@2024.4.13"
         }
       }

--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -37,10 +37,13 @@ pkg.files = Array.from(
 );
 
 // The high-level module needs these at runtime; consumers provide them.
+// geotiff accepts v2 or v3: only the stable high-level API (fromUrl,
+// fromArrayBuffer, getImage, getGeoKeys, readRasters) is used, which is
+// unchanged across the v3 major, so the range must not block v3 consumers.
 pkg.peerDependencies = {
   "whitebox-wasm": "^0.4.0",
   proj4: "^2.15.0",
-  geotiff: "^2.1.0",
+  geotiff: "^2.1.0 || ^3.0.0",
   "geotiff-geokeys-to-proj4": "^2024.4.13",
 };
 pkg.keywords = [


### PR DESCRIPTION
## What

Widen the `geotiff` peer dependency from `^2.1.0` to `^2.1.0 || ^3.0.0` so consumers on geotiff v3 (e.g. [GeoLibre](https://github.com/opengeos/GeoLibre)) can install cog-tiler-wasm without `--legacy-peer-deps`/`--force`.

## Why

cog-tiler-wasm only uses geotiff's stable high-level API — `fromUrl`, `fromArrayBuffer`, `getImage`, `getGeoKeys`, `readRasters` — all unchanged across the v3 major. The old `^2.1.0` pin caused an `ERESOLVE` peer conflict against geotiff@3, and the npm workarounds (`--legacy-peer-deps`/`--force`) break dependency hoisting in consumer monorepos. Verified the engine renders a real COG (NLCD land cover) correctly with geotiff@3.

The other peers already satisfy current consumer versions and are unchanged:
- `whitebox-wasm` `^0.4.0`
- `proj4` `^2.15.0`
- `geotiff-geokeys-to-proj4` `^2024.4.13`

## Changes

- `scripts/prepare-pkg.mjs`: peer `geotiff` → `^2.1.0 || ^3.0.0`.
- `demo/index.html`, `README.md`: import-map `geotiff` → `3.0.5` (exercise v3).
- Bump version to `0.2.2` (`Cargo.toml`, `Cargo.lock`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version
  * Expanded dependency compatibility to support multiple versions of the geotiff library

* **Documentation**
  * Updated references to use the latest geotiff library version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->