### PR TITLE
fix(geotiff): read ColorMap via geotiff v3 deferred-field API (0.2.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cog-tiler-wasm"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cog-tiler-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/opengeos/cog-tiler-wasm"

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -147,6 +147,24 @@ function fitSize(extW, extH, maxSize, width, height) {
     : [Math.max(1, Math.round(max * ar)), max];
 }
 
+/**
+ * Read a TIFF tag from a geotiff.js image across major versions. geotiff v2
+ * exposes tags as direct `fileDirectory` properties; v3 defers them behind
+ * `fileDirectory.loadValue()` (large arrays such as ColorMap are not actualized
+ * eagerly), so a direct property read returns undefined there. Returns the tag
+ * value, or undefined when the tag is absent.
+ */
+async function readTiffTag(img, name) {
+  const fd = img.fileDirectory;
+  if (fd && fd[name] !== undefined) return fd[name]; // geotiff v2
+  if (typeof fd?.loadValue === "function") {
+    // geotiff v3: skip the load when the tag is absent so loadValue doesn't throw.
+    if (typeof fd.hasTag === "function" && !fd.hasTag(name)) return undefined;
+    return fd.loadValue(name);
+  }
+  return undefined;
+}
+
 /** Build a 256-entry RGBA palette from a TIFF ColorMap (16-bit R,G,B blocks). */
 function buildPalette(colorMap) {
   if (!colorMap) return null;
@@ -248,7 +266,7 @@ export async function openCog(source) {
   if (stream.epsg !== 3857 || multiBand) {
     tiff = await openTiff();
     img = await tiff.getImage();
-    planar = multiBand && img.fileDirectory.PlanarConfiguration === 2;
+    planar = multiBand && (await readTiffTag(img, "PlanarConfiguration")) === 2;
   }
   const base = { url: label, range, stream, levels, gt, nodata: stream.nodata, tiff, planar };
 
@@ -268,7 +286,7 @@ export async function openCog(source) {
   if (!srcDef) throw new Error("could not derive source CRS from GeoTIFF geokeys");
   const toSource = proj4("EPSG:3857", srcDef); // forward: mercator -> source
   const toLonLat = proj4(srcDef, "EPSG:4326"); // forward: source -> lon/lat
-  const palette = buildPalette(img.fileDirectory.ColorMap);
+  const palette = buildPalette(await readTiffTag(img, "ColorMap"));
 
   // fitBounds bounds: transform the source corners to lon/lat.
   const fw = levels[0].width, fh = levels[0].height;


### PR DESCRIPTION
## What

Read `ColorMap` and `PlanarConfiguration` through geotiff's version-agnostic API so paletted (categorical) COGs render with their built-in color table on **geotiff v3**.

## Why

geotiff v3 made `fileDirectory` fields **deferred** — large arrays such as `ColorMap` are no longer actualized eagerly, so the v2-style direct reads return `undefined`:

```js
img.fileDirectory.ColorMap            // v2: array  | v3: undefined
img.fileDirectory.PlanarConfiguration // v2: number | v3: undefined
```

With `ColorMap` lost, `buildPalette()` returned `null` and the renderer fell back to the default **viridis** colormap — e.g. NLCD land cover came out in viridis instead of its legend colors. (Surfaced after widening the geotiff peer to v3 in #17.)

## Fix

Add a cross-version `readTiffTag(img, name)` helper — direct property on v2, `fileDirectory.loadValue()` (guarded by `hasTag`) on v3 — and use it for both tags.

Verified against the NLCD COG on geotiff@3: the loaded `ColorMap` yields the official legend colors — water `(70,107,159)`, evergreen forest `(28,95,44)`, crops `(171,108,40)`, developed `(235,0,0)`.

Bumps to **0.2.3**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.2.3

* **Bug Fixes**
  * Improved compatibility with multiple versions of the geotiff.js library

<!-- end of auto-generated comment: release notes by coderabbit.ai -->