### PR TITLE
fix(reader): read Blob/File sources via ranged slices; 0.2.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,7 +49,7 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cog-tiler-wasm"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "serde",
  "serde-wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/cog-tiler-wasm"]
 resolver = "2"
 
 [workspace.package]
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/opengeos/cog-tiler-wasm"

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -124,8 +124,8 @@ export declare function init(): Promise<unknown>;
 
 /**
  * Open a COG and return a {@link CogSource} ready to render XYZ tiles. Pass a URL
- * string (read via HTTP range) or in-memory bytes / a Blob / a File for a local
- * raster.
+ * string (read via HTTP range), a Blob / File (read via ranged slices, so
+ * multi-GB local rasters never load whole), or in-memory bytes.
  */
 export declare function openCog(source: string | ArrayBuffer | Uint8Array | Blob): Promise<CogSource>;
 

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -240,18 +240,29 @@ function sampleWindowBilinear(buf, w, h, fc, fr) {
   return top + (bot - top) * ty;
 }
 
-// Build a byte reader from a URL string or an in-memory source (ArrayBuffer,
-// Uint8Array, or Blob/File). `range(a,b)` yields bytes [a..b]; `openTiff()`
+// Build a byte reader from a URL string, a Blob/File, or an in-memory source
+// (ArrayBuffer, Uint8Array). `range(a,b)` yields bytes [a..b]; `openTiff()`
 // returns a geotiff.js GeoTIFF for reading the CRS / color table from the header.
 async function makeReader(source) {
   if (typeof source === "string") {
     return { label: source, range: rangeFetcher(source), openTiff: () => GeoTIFF.fromUrl(source) };
   }
+  // Blob / File: read on demand via ranged slices, mirroring the URL path.
+  // Slurping the whole file (blob.arrayBuffer()) throws NotReadableError in
+  // Chromium for multi-GB rasters (e.g. the 7 GB GEBCO GeoTIFF) — and only the
+  // header prefix and the requested tiles are ever needed.
+  if (typeof Blob !== "undefined" && source instanceof Blob) {
+    return {
+      label: source.name || "(local file)",
+      range: async (a, b) => new Uint8Array(await source.slice(a, b + 1).arrayBuffer()),
+      openTiff: () => GeoTIFF.fromBlob(source),
+    };
+  }
   let bytes;
   if (source instanceof Uint8Array) bytes = source;
   else if (source instanceof ArrayBuffer) bytes = new Uint8Array(source);
   else if (source && typeof source.arrayBuffer === "function") {
-    bytes = new Uint8Array(await source.arrayBuffer()); // Blob / File
+    bytes = new Uint8Array(await source.arrayBuffer()); // exotic Blob-likes
   } else {
     throw new Error("openCog: expected a URL string, ArrayBuffer, Uint8Array, or Blob");
   }
@@ -270,10 +281,11 @@ async function makeReader(source) {
 
 /**
  * Open a COG and return a {@link CogSource} ready to render XYZ tiles. `source`
- * is a URL string (read via HTTP range) or in-memory bytes / a Blob / a File for
- * a local raster. Detects EPSG:3857 (fast path) vs. any other CRS (warp path),
- * reading the source projection + color table from the GeoTIFF header (which
- * whitebox-wasm 0.4.0 does not expose).
+ * is a URL string (read via HTTP range), a Blob / File (read via ranged slices,
+ * so multi-GB local rasters never load whole), or in-memory bytes. Detects
+ * EPSG:3857 (fast path) vs. any other CRS (warp path), reading the source
+ * projection + color table from the GeoTIFF header (which whitebox-wasm 0.4.0
+ * does not expose).
  */
 export async function openCog(source) {
   await init();

--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -38,8 +38,8 @@ pkg.files = Array.from(
 
 // The high-level module needs these at runtime; consumers provide them.
 // geotiff accepts v2 or v3: only the stable high-level API (fromUrl,
-// fromArrayBuffer, getImage, getGeoKeys, readRasters) is used, which is
-// unchanged across the v3 major, so the range must not block v3 consumers.
+// fromBlob, fromArrayBuffer, getImage, getGeoKeys, readRasters) is used, which
+// is unchanged across the v3 major, so the range must not block v3 consumers.
 pkg.peerDependencies = {
   "whitebox-wasm": "^0.4.0",
   proj4: "^2.15.0",


### PR DESCRIPTION
## Summary

Opening a multi-GB local GeoTIFF (e.g. the 7 GB GEBCO 2026 grid) through `openCog(file)` failed with:

```
NotReadableError: The requested file could not be read, typically due to permission problems that have occurred after a reference to a file was acquired.
```

## Root cause

`makeReader` slurped Blob/File sources whole via `source.arrayBuffer()`. Chromium cannot materialize a multi-GB ArrayBuffer from a Blob (and the wasm heap could not hold it either), so the read fails. URL sources already read via HTTP range requests; Blobs had no equivalent.

## Fix

Give Blob/File sources a ranged reader mirroring the URL path:

- `range(a, b)` slices the blob on demand: `source.slice(a, b + 1).arrayBuffer()` — only the header prefix and requested tiles are ever read.
- geotiff.js header reads go through `GeoTIFF.fromBlob` (present in both the v2 and v3 peer range).
- `ArrayBuffer`/`Uint8Array` sources keep the in-memory path unchanged, and exotic `arrayBuffer()`-only objects keep the old fallback.

Bumps version to 0.2.5.

## Testing

Verified in a real browser via the maplibre-gl-raster example app under the cog-tiler-wasm engine: the 7 GB `gebco_2026.tif` opens, computes stats, renders the global extent, and serves tiles across 5+ zoom levels with zero console errors. Small remote COGs (URL path) unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for opening local raster files without loading entire multi-gigabyte files into memory.
  * Added support for ranged reading from `Blob` and `File` sources.

* **Documentation**
  * Clarified supported data sources and raster reading behavior.
  * Updated package preparation documentation.

* **Chores**
  * Bumped the package version from 0.2.4 to 0.2.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->