### PR TITLE
ci(release): use Node 24 so the npm Trusted Publishing upgrade works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # npm@latest (12+) requires Node >= 22; keep this current or the
+          # Trusted Publishing npm upgrade below fails with EBADENGINE.
+          node-version: 24
           registry-url: https://registry.npmjs.org
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
The v0.2.5 release run failed at the 'Upgrade npm for Trusted Publishing' step: npm@latest is now npm 12, which requires Node >= 22, while the workflow pinned Node 20 (EBADENGINE). Bump setup-node to Node 24.

After merging, the v0.2.5 publish will be re-run via workflow_dispatch.