### PR TITLE
fix: mask nodata before bilinear interpolation, not after

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: JS unit tests
+        run: npm test
+
       - name: Install Rust (wasm target)
         uses: dtolnay/rust-toolchain@stable
         with:

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -25,6 +25,7 @@ import initTiler, { colorize, colormap_names } from "./cog_tiler_wasm.js";
 import proj4 from "proj4";
 import * as GeoTIFF from "geotiff";
 import geokeysToProj4 from "geotiff-geokeys-to-proj4";
+import { sampleWindowBilinear } from "./sampling.js";
 
 const OS = 20037508.342789244; // Web Mercator half-extent (m)
 const TILE = 256; // output tile size (px)
@@ -220,22 +221,6 @@ function bilin(v00, v10, v01, v11, tx, ty) {
   if (!isFinite(v00) || !isFinite(v10) || !isFinite(v01) || !isFinite(v11)) {
     return isFinite(v00) ? v00 : NaN; // near projection edges
   }
-  const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
-  return top + (bot - top) * ty;
-}
-
-// Bilinear sample of a row-major window at fractional (fc,fr). Returns NaN when
-// the cell center is outside the window so out-of-raster pixels stay transparent
-// (no edge smear); falls back to nearest at the window edge / next to nodata.
-function sampleWindowBilinear(buf, w, h, fc, fr) {
-  const c0 = Math.floor(fc), r0 = Math.floor(fr);
-  if (c0 < 0 || c0 >= w || r0 < 0 || r0 >= h) return NaN;
-  const c1 = Math.min(c0 + 1, w - 1), r1 = Math.min(r0 + 1, h - 1);
-  const v00 = buf[r0 * w + c0];
-  if (Number.isNaN(v00)) return NaN;
-  const v10 = buf[r0 * w + c1], v01 = buf[r1 * w + c0], v11 = buf[r1 * w + c1];
-  if (Number.isNaN(v10) || Number.isNaN(v01) || Number.isNaN(v11)) return v00; // edge/nodata
-  const tx = fc - c0, ty = fr - r0;
   const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
   return top + (bot - top) * ty;
 }
@@ -569,7 +554,7 @@ export class CogSource {
           // RGB composite: bilinear-sample each band, rescale -> curve -> gamma.
           let ok = true;
           for (let k = 0; k < 3; k++) {
-            const v = sampleWindowBilinear(bufs[k], ww, hh, fcol, frow);
+            const v = sampleWindowBilinear(bufs[k], ww, hh, fcol, frow, ndSet ? nodata : undefined);
             if (!isFinite(v) || (ndSet && v === nodata)) { ok = false; break; }
             const [mn, mx] = rescales[k] || rescales[0];
             const t = transferCurve(Math.max(0, Math.min(1, (v - mn) / ((mx - mn) || 1))), stretch, gamma);
@@ -579,7 +564,7 @@ export class CogSource {
           else { out[o] = out[o + 1] = out[o + 2] = 0; }
         } else {
           // Continuous single band: bilinear; colormap applied below.
-          const v = sampleWindowBilinear(bufs[0], ww, hh, fcol, frow);
+          const v = sampleWindowBilinear(bufs[0], ww, hh, fcol, frow, ndSet ? nodata : undefined);
           if (!isFinite(v) || (ndSet && v === nodata)) continue;
           grid[py * outW + px] = v;
         }

--- a/crates/cog-tiler-wasm/src/lib.rs
+++ b/crates/cog-tiler-wasm/src/lib.rs
@@ -265,7 +265,14 @@ impl CogTiler {
             let sy = ((ty as f64 + 0.5) / ts) * win_h as f64 - 0.5;
             for tx in 0..TILE_SIZE {
                 let sx = ((tx as f64 + 0.5) / ts) * win_w as f64 - 0.5;
-                let v = sample_bilinear(&pixels, win_w, win_h, sx, sy);
+                // The sentinel is handed to the sampler, not just tested on its
+                // result: interpolating across a nodata boundary blends the
+                // sentinel into the value, and the blend equals neither the
+                // sentinel nor NaN, so the test below cannot recognise it. Only
+                // masked when `nodata_alpha` is set, so a caller that asked for
+                // nodata to be rendered as data still gets it interpolated.
+                let mask = if nodata_alpha { self.nodata } else { None };
+                let v = sample_bilinear(&pixels, win_w, win_h, sx, sy, mask);
 
                 let idx = ((ty * TILE_SIZE + tx) * 4) as usize;
                 let is_nodata = match self.nodata {
@@ -357,7 +364,16 @@ impl CogTiler {
 
 /// Bilinear sample of a row-major `f64` grid, clamping at the edges. Returns
 /// `NaN` if any contributing sample is `NaN` so nodata/edges stay transparent.
-fn sample_bilinear(data: &[f64], w: u32, h: u32, x: f64, y: f64) -> f64 {
+///
+/// `nodata` is the declared sentinel when it should be masked. A sentinel
+/// neighbour is treated exactly like a `NaN` one, because interpolating across
+/// the boundary would otherwise blend it into the result: the product matches
+/// neither the sentinel nor `NaN`, so the caller's equality test cannot catch
+/// it, and with a large negative sentinel (-9999 is the GDAL convention) it
+/// clamps to the bottom of the rescale window and paints a ring of the
+/// colormap's first colour around every nodata edge -- a blue border under
+/// `jet`.
+fn sample_bilinear(data: &[f64], w: u32, h: u32, x: f64, y: f64, nodata: Option<f64>) -> f64 {
     let w = w as i64;
     let h = h as i64;
     let x0 = x.floor() as i64;
@@ -374,10 +390,68 @@ fn sample_bilinear(data: &[f64], w: u32, h: u32, x: f64, y: f64) -> f64 {
     let v10 = at(x0 + 1, y0);
     let v01 = at(x0, y0 + 1);
     let v11 = at(x0 + 1, y0 + 1);
-    if v00.is_nan() || v10.is_nan() || v01.is_nan() || v11.is_nan() {
+    // Mirrors the caller's tolerance so the two agree on what counts as nodata.
+    let is_void = |v: f64| match nodata {
+        Some(nd) => v.is_nan() || v == nd || (v - nd).abs() <= f64::EPSILON,
+        None => v.is_nan(),
+    };
+    if is_void(v00) || is_void(v10) || is_void(v01) || is_void(v11) {
         return f64::NAN;
     }
     let top = v00 + (v10 - v00) * fx;
     let bot = v01 + (v11 - v01) * fx;
     top + (bot - top) * fy
+}
+
+#[cfg(test)]
+mod sample_bilinear_tests {
+    use super::sample_bilinear;
+
+    /// GDAL's conventional float sentinel, and the one the PACE chlorophyll
+    /// COGs that surfaced this bug declare.
+    const ND: f64 = -9999.0;
+
+    #[test]
+    fn does_not_blend_a_sentinel_into_a_neighbouring_value() {
+        // A land/water edge: left column valid chlorophyll, right column nodata.
+        let data = [2.5, ND, 3.0, ND];
+        for step in 0..4 {
+            let x = step as f64 * 0.25;
+            let v = sample_bilinear(&data, 2, 2, x, 0.0, Some(ND));
+            // Interpolating toward the sentinel used to drag this to roughly
+            // -2500 / -5000 / -7500, which matched neither the sentinel nor NaN,
+            // so it survived the caller's mask, clamped to the bottom of the
+            // rescale window, and painted the colormap's first colour.
+            assert!(v.is_nan(), "x={x} must be masked, got {v}");
+        }
+    }
+
+    #[test]
+    fn still_interpolates_when_no_sentinel_is_masked() {
+        let data = [0.0, 10.0, 0.0, 10.0];
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.5, 0.0, None), 5.0);
+    }
+
+    #[test]
+    fn a_sentinel_value_is_ordinary_data_when_not_masked() {
+        // With nodata_alpha off the caller wants nodata rendered, so -9999 must
+        // interpolate like any other value.
+        let data = [0.0, -9999.0, 0.0, -9999.0];
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.5, 0.0, None), -4999.5);
+    }
+
+    #[test]
+    fn keeps_the_existing_nan_guard() {
+        let data = [2.5, f64::NAN, 3.0, f64::NAN];
+        assert!(sample_bilinear(&data, 2, 2, 0.5, 0.0, Some(ND)).is_nan());
+        assert!(sample_bilinear(&data, 2, 2, 0.5, 0.0, None).is_nan());
+    }
+
+    #[test]
+    fn interpolates_across_an_interior_window_of_valid_data() {
+        let data = [0.0, 10.0, 20.0, 30.0];
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.5, 0.0, Some(ND)), 5.0);
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.0, 0.5, Some(ND)), 10.0);
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.5, 0.5, Some(ND)), 15.0);
+    }
 }

--- a/crates/cog-tiler-wasm/src/lib.rs
+++ b/crates/cog-tiler-wasm/src/lib.rs
@@ -395,8 +395,17 @@ fn sample_bilinear(data: &[f64], w: u32, h: u32, x: f64, y: f64, nodata: Option<
         Some(nd) => v.is_nan() || v == nd || (v - nd).abs() <= f64::EPSILON,
         None => v.is_nan(),
     };
-    if is_void(v00) || is_void(v10) || is_void(v01) || is_void(v11) {
+    // The anchor itself being void means the sample sits on nodata: stay
+    // transparent. A void *neighbour* only means the sample sits next to an
+    // edge, so fall back to nearest and hold the anchor's own valid value.
+    // Returning NaN there instead would erode a pixel of real data all the way
+    // around every nodata boundary, which for an ocean product means shaving the
+    // coastline off the data on each tile.
+    if is_void(v00) {
         return f64::NAN;
+    }
+    if is_void(v10) || is_void(v01) || is_void(v11) {
+        return v00;
     }
     let top = v00 + (v10 - v00) * fx;
     let bot = v01 + (v11 - v01) * fx;
@@ -422,7 +431,10 @@ mod sample_bilinear_tests {
             // -2500 / -5000 / -7500, which matched neither the sentinel nor NaN,
             // so it survived the caller's mask, clamped to the bottom of the
             // rescale window, and painted the colormap's first colour.
-            assert!(v.is_nan(), "x={x} must be masked, got {v}");
+            assert_eq!(
+                v, 2.5,
+                "x={x} must hold the valid value, not blend toward nodata"
+            );
         }
     }
 
@@ -441,10 +453,18 @@ mod sample_bilinear_tests {
     }
 
     #[test]
-    fn keeps_the_existing_nan_guard() {
+    fn falls_back_to_nearest_beside_a_nan_neighbour() {
         let data = [2.5, f64::NAN, 3.0, f64::NAN];
-        assert!(sample_bilinear(&data, 2, 2, 0.5, 0.0, Some(ND)).is_nan());
-        assert!(sample_bilinear(&data, 2, 2, 0.5, 0.0, None).is_nan());
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.5, 0.0, Some(ND)), 2.5);
+        assert_eq!(sample_bilinear(&data, 2, 2, 0.5, 0.0, None), 2.5);
+    }
+
+    #[test]
+    fn stays_transparent_when_the_anchor_itself_is_void() {
+        // Sampling *on* nodata (rather than beside it) must not be rescued by
+        // the nearest fallback -- that pixel really has no data.
+        assert!(sample_bilinear(&[ND, 2.5, ND, 3.0], 2, 2, 0.0, 0.0, Some(ND)).is_nan());
+        assert!(sample_bilinear(&[f64::NAN, 2.5, f64::NAN, 3.0], 2, 2, 0.0, 0.0, None).is_nan());
     }
 
     #[test]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "Dev scripts for the cog-tiler-wasm demo (the published package is assembled under crates/cog-tiler-wasm/pkg).",
   "scripts": {
+    "test": "node --test \"tests/*.test.mjs\"",
     "gen:colormaps": "node scripts/gen-colormaps.mjs",
     "build:wasm": "wasm-pack build crates/cog-tiler-wasm --release --target web --out-dir ../../demo",
     "assemble:demo": "node scripts/assemble-demo.mjs",

--- a/sampling.js
+++ b/sampling.js
@@ -1,0 +1,33 @@
+/**
+ * Pure resampling helpers, kept dependency-free so they can be unit-tested
+ * without loading the wasm/geotiff stack that `cog-tiler.js` pulls in.
+ */
+
+// Bilinear sample of a row-major window at fractional (fc,fr). Returns NaN when
+// the cell center is outside the window so out-of-raster pixels stay transparent
+// (no edge smear); falls back to nearest at the window edge / next to nodata.
+//
+// `nodata` is the declared sentinel, when the dataset has one. It must be tested
+// here rather than only on the result: interpolating across the boundary blends
+// the sentinel into the value, and the product matches neither the sentinel nor
+// NaN, so a caller's `v === nodata` check cannot recognize it. With a large
+// negative sentinel (-9999 is the GDAL convention) the blend lands far below the
+// rescale window, clamps to its low end, and paints a ring of the colormap's
+// first color around every nodata boundary -- e.g. a blue border along a swath
+// edge under `jet`. Treating a sentinel neighbor exactly like a NaN one keeps
+// the boundary pixel at its own valid value instead.
+export function sampleWindowBilinear(buf, w, h, fc, fr, nodata) {
+  const c0 = Math.floor(fc), r0 = Math.floor(fr);
+  if (c0 < 0 || c0 >= w || r0 < 0 || r0 >= h) return NaN;
+  const c1 = Math.min(c0 + 1, w - 1), r1 = Math.min(r0 + 1, h - 1);
+  // `nodata` is undefined when the dataset declares none; `v === undefined` is
+  // false for every numeric sample, so the test costs nothing in that case.
+  const isVoid = (v) => Number.isNaN(v) || v === nodata;
+  const v00 = buf[r0 * w + c0];
+  if (isVoid(v00)) return NaN;
+  const v10 = buf[r0 * w + c1], v01 = buf[r1 * w + c0], v11 = buf[r1 * w + c1];
+  if (isVoid(v10) || isVoid(v01) || isVoid(v11)) return v00; // edge/nodata
+  const tx = fc - c0, ty = fr - r0;
+  const top = v00 + (v10 - v00) * tx, bot = v01 + (v11 - v01) * tx;
+  return top + (bot - top) * ty;
+}

--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -15,6 +15,7 @@ const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const pkgDir = process.argv[2] || join(root, "crates/cog-tiler-wasm/pkg");
 
 copyFileSync(join(root, "cog-tiler.js"), join(pkgDir, "cog-tiler.js"));
+copyFileSync(join(root, "sampling.js"), join(pkgDir, "sampling.js"));
 copyFileSync(join(root, "cog-tiler.d.ts"), join(pkgDir, "cog-tiler.d.ts"));
 copyFileSync(join(root, "README.md"), join(pkgDir, "README.md"));
 copyFileSync(join(root, "LICENSE"), join(pkgDir, "LICENSE"));
@@ -33,7 +34,14 @@ pkg.exports = {
   "./wasm": { types: "./cog_tiler_wasm.d.ts", default: "./cog_tiler_wasm.js" },
 };
 pkg.files = Array.from(
-  new Set([...(pkg.files || []), "cog-tiler.js", "cog-tiler.d.ts", "README.md", "LICENSE"]),
+  new Set([
+    ...(pkg.files || []),
+    "cog-tiler.js",
+    "sampling.js",
+    "cog-tiler.d.ts",
+    "README.md",
+    "LICENSE",
+  ]),
 );
 
 // The high-level module needs these at runtime; consumers provide them.

--- a/tests/sample-window-bilinear.test.mjs
+++ b/tests/sample-window-bilinear.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { sampleWindowBilinear as sample } from '../sampling.js';
+
+// GDAL's conventional float sentinel, and the one the PACE chlorophyll COGs
+// that surfaced this bug declare.
+const ND = -9999;
+
+test('does not blend a numeric nodata sentinel into a neighbouring value', () => {
+  // A swath edge: the left column is valid chlorophyll, the right is nodata.
+  const buf = Float64Array.from([2.5, ND, 3.0, ND]);
+  for (const tx of [0, 0.25, 0.5, 0.75]) {
+    const v = sample(buf, 2, 2, tx, 0, ND);
+    // Interpolating toward the sentinel used to drag the sample to roughly
+    // -2500 / -5000 / -7500. Those match neither the sentinel nor NaN, so the
+    // caller's `v === nodata` mask let them through, they clamped to the bottom
+    // of the rescale window, and the colormap's first colour (dark navy under
+    // `jet`) painted a border along every nodata boundary.
+    assert.equal(v, 2.5, `tx=${tx} must hold the valid value, not blend toward nodata`);
+  }
+});
+
+test('still interpolates normally when the dataset declares no nodata', () => {
+  const buf = Float64Array.from([0, 10, 0, 10]);
+  assert.equal(sample(buf, 2, 2, 0.5, 0, undefined), 5);
+});
+
+test('a sentinel value is not special-cased when no nodata is declared', () => {
+  // Without a declared sentinel, -9999 is ordinary data and must interpolate.
+  const buf = Float64Array.from([0, -9999, 0, -9999]);
+  assert.equal(sample(buf, 2, 2, 0.5, 0, undefined), -4999.5);
+});
+
+test('keeps the existing NaN-neighbour nearest fallback', () => {
+  const buf = Float64Array.from([2.5, NaN, 3.0, NaN]);
+  assert.equal(sample(buf, 2, 2, 0.5, 0, ND), 2.5);
+});
+
+test('sampling on a nodata cell stays transparent', () => {
+  const buf = Float64Array.from([ND, 2.5, ND, 3.0]);
+  assert.ok(Number.isNaN(sample(buf, 2, 2, 0, 0, ND)));
+});
+
+test('sampling outside the window stays transparent', () => {
+  const buf = Float64Array.from([1, 2, 3, 4]);
+  assert.ok(Number.isNaN(sample(buf, 2, 2, -1, 0, ND)));
+  assert.ok(Number.isNaN(sample(buf, 2, 2, 0, 2, ND)));
+});
+
+test('interpolates across an interior window of valid data', () => {
+  const buf = Float64Array.from([0, 10, 20, 30]);
+  assert.equal(sample(buf, 2, 2, 0.5, 0, ND), 5);
+  assert.equal(sample(buf, 2, 2, 0, 0.5, ND), 10);
+  assert.equal(sample(buf, 2, 2, 0.5, 0.5, ND), 15);
+});


### PR DESCRIPTION
## Problem

Rendering a single-band float COG that declares a numeric nodata sentinel draws a **coloured border around every nodata boundary** — a blue frame under `jet`, tracing coastlines and swath edges.

Both bilinear samplers interpolate raw pixel values and only *then* test the result against the sentinel:

```js
const v = sampleWindowBilinear(bufs[0], ww, hh, fcol, frow);
if (!isFinite(v) || (ndSet && v === nodata)) continue;
```

At a boundary the interpolant blends the sentinel into the value. With GDAL's usual `-9999`, a pixel with one nodata neighbour comes out around `-2500`, which equals neither the sentinel nor `NaN` — so it survives the mask, clamps to the bottom of the rescale window, and gets painted with the colormap's first colour.

Both samplers guarded only against `NaN` neighbours, so a numeric sentinel passed straight through. The JS doc comment already claimed it "falls back to nearest ... next to nodata" — the intent was there, only the `NaN` spelling was implemented.

## Fix

Hand the sentinel to the samplers and treat a matching neighbour exactly like a `NaN` one. Each keeps its own file's existing convention:

- **`sampleWindowBilinear`** (JS, the warp path that serves tiled renders) keeps its nearest-neighbour fallback, holding the boundary pixel at its own valid value.
- **`sample_bilinear`** (Rust, `CogTiler::render`) keeps returning `NaN`, and masks *only* when `nodata_alpha` is set — a caller that asked for nodata to be rendered as data still gets it interpolated.

The JS sampler moves into its own dependency-free `sampling.js` so it can be unit tested without loading the wasm/geotiff stack; `prepare-pkg.mjs` ships it alongside `cog-tiler.js`.

## Verification

Against real PACE L2 chlorophyll COGs (`float32`, `NoData=-9999`, `jet` over `[0,30]`), 15 tiles at z6 over the Caribbean:

| | opaque px | pixels on jet's exact floor | warm end (real high-chla) |
|---|---|---|---|
| before | 24,002 | **13,906 (57.9%)** | 111 (0.46%) |
| after | 16,636 | **0 (0.00%)** | 237 (1.42%) |

The contamination signature is eliminated, 7,366 falsely-opaque pixels become correctly transparent, and genuine high-chlorophyll water that was being overwritten with navy more than doubles.

## Tests

- 5 Rust unit tests (`cargo test`, 14 pass) covering the sentinel guard, the unmasked passthrough, the existing `NaN` guard, and interior interpolation.
- 7 JS unit tests via `node --test`, wired up as `npm test` and added to CI (the repo had no JS test step before).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved raster interpolation near nodata values to prevent invalid data from blending into neighboring valid pixels.
  * Preserved correct handling of missing values and sampling outside the available window.
  * Applied consistent nodata behavior across JavaScript and WebAssembly rendering.

* **Testing**
  * Added automated coverage for interpolation, nodata handling, and boundary conditions.
  * Added the npm test command to the CI build workflow.

* **Package Updates**
  * Included the shared sampling functionality in published npm packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->