### PR TITLE
fix: open plain GeoTIFFs, and stop an overview-less one from wedging the tab

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,10 +34,15 @@ jobs:
           cp cog-tiler.js sampling.js header-window.js site/
           cp examples/sample-3857-cog.tif site/sample-3857-cog.tif
           rm -f site/.gitignore
-          # Cache-bust the loader + module + wasm together so returning visitors
-          # never pair a freshly built module with a stale cached glue file.
+          # Cache-bust the loader + module + wasm + the module's siblings together
+          # so returning visitors never pair a freshly built module with a stale
+          # cached glue file.
           sed -i "s/__BUILD__/${GITHUB_SHA}/g" site/index.html
-          sed -i "s#\./cog_tiler_wasm\.js#./cog_tiler_wasm.js?v=${GITHUB_SHA}#g" site/cog-tiler.js
+          sed -i \
+            -e "s#\./cog_tiler_wasm\.js#./cog_tiler_wasm.js?v=${GITHUB_SHA}#g" \
+            -e "s#\./sampling\.js#./sampling.js?v=${GITHUB_SHA}#g" \
+            -e "s#\./header-window\.js#./header-window.js?v=${GITHUB_SHA}#g" \
+            site/cog-tiler.js
       - uses: actions/configure-pages@v4
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
           wasm-pack build crates/cog-tiler-wasm --release --target web \
             --out-dir "$GITHUB_WORKSPACE/site"
           cp demo/index.html site/index.html
-          cp cog-tiler.js site/cog-tiler.js
+          cp cog-tiler.js sampling.js header-window.js site/
           cp examples/sample-3857-cog.tif site/sample-3857-cog.tif
           rm -f site/.gitignore
           # Cache-bust the loader + module + wasm together so returning visitors

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ node_modules
 # is canonical at the repo root and copied into demo/ for local serving.
 /demo/cog_tiler_wasm*
 /demo/cog-tiler.js
+/demo/sampling.js
+/demo/header-window.js
 /demo/package.json
 /demo/.gitignore
 /demo/sample-3857-cog.tif

--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ map.addLayer({ id: "cog", type: "raster", source: "cog" });
 // and source.renderTileRGBA(z, x, y, render) / renderTilePNG(...) are also exposed.
 ```
 
+### Plain GeoTIFFs (not only COGs)
+
+`openCog` also opens a **plain** GeoTIFF - what GDAL and libtiff write unless
+you ask for a COG. Their difference is where the directory sits: a COG keeps
+every IFD at the front of the file, while a plain GeoTIFF puts it *after* the
+pixel data, so growing a front-of-file prefix would have to pull in the whole
+file to reach it. The header is instead read from a window around the directory
+(a 74 MB raster needs 704 KB of it).
+
+Two things still make a COG the better input:
+
+- **No overviews.** A plain GeoTIFF usually has only full resolution, so a
+  zoomed-out tile would have to read the entire image. Past a read ceiling of
+  ~16.8M source samples those tiles render **blank** and the reason is logged
+  once - the raster still opens, and zooming in brings it back. Run `gdaladdo`,
+  or convert to a COG, to see it at every zoom.
+- **No tile index at the front**, so opening costs a second range request.
+
 ### TiTiler-style COG API
 
 `CogSource` mirrors the read endpoints of

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -64,7 +64,12 @@ export declare class CogSource {
   readonly hasPalette: boolean;
   /** Render an XYZ tile to a 256x256 RGBA buffer, or null if empty. (Paletted
    * tiles are a `Uint8ClampedArray`; continuous tiles are the wasm `render()`
-   * `Uint8Array`.) */
+   * `Uint8Array`.)
+   *
+   * Also null when the tile would need more source pixels than one read allows,
+   * which happens on a large raster with no overviews: full resolution is the
+   * only thing there is to read, so a zoomed-out tile would pull in the whole
+   * image. Zooming in shrinks the window until it fits. */
   renderTileRGBA(
     z: number,
     x: number,
@@ -126,8 +131,25 @@ export declare function init(): Promise<unknown>;
  * Open a COG and return a {@link CogSource} ready to render XYZ tiles. Pass a URL
  * string (read via HTTP range), a Blob / File (read via ranged slices, so
  * multi-GB local rasters never load whole), or in-memory bytes.
+ *
+ * Plain (non-COG) GeoTIFFs open too: their directory sits after the pixel data
+ * rather than at the front, and it is read from there. They usually carry no
+ * overviews, though, so a zoomed-out view of a very large one renders blank
+ * rather than reading the whole raster — see {@link CogSource.renderTileRGBA}.
  */
 export declare function openCog(source: string | ArrayBuffer | Uint8Array | Blob): Promise<CogSource>;
+
+/**
+ * Widen the byte window `[start, end)` so it covers `want`, the offset a header
+ * parse said it still needed, growing in whichever direction the miss lies.
+ * Returns `null` when `want` already falls inside the window.
+ */
+export declare function widenHeaderWindow(
+  start: number,
+  end: number,
+  want: number,
+  pad?: number,
+): { start: number; end: number } | null;
 
 /** Encode an RGBA buffer to PNG bytes (browser; uses OffscreenCanvas).
  *  Defaults to 256x256 when `width`/`height` are omitted. */

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -20,17 +20,38 @@
  *   registerCogProtocol(maplibregl, "cog", () => ({ source: src, render: { min, max, colormap } }));
  *   map.addSource("cog", { type: "raster", tiles: ["cog://{z}/{x}/{y}"], tileSize: 256 });
  */
-import initWhitebox, { CogStream } from "whitebox-wasm";
+import initWhitebox, { CogStream, first_ifd_offset } from "whitebox-wasm";
 import initTiler, { colorize, colormap_names } from "./cog_tiler_wasm.js";
 import proj4 from "proj4";
 import * as GeoTIFF from "geotiff";
 import geokeysToProj4 from "geotiff-geokeys-to-proj4";
 import { sampleWindowBilinear } from "./sampling.js";
+import {
+  HEADER_PREFIX,
+  HEADER_TAIL,
+  MAX_HEADER_PREFIX,
+  MAX_HEADER_TAIL,
+  widenHeaderWindow,
+} from "./header-window.js";
+
+export { widenHeaderWindow } from "./header-window.js";
 
 const OS = 20037508.342789244; // Web Mercator half-extent (m)
 const TILE = 256; // output tile size (px)
 const NG = 16; // warp grid cells per axis
 const MAX_CACHED_TILES = 256; // ~0.5 MB each at 256x256 f64
+
+// Offset named by whitebox-wasm when header parsing walks past the bytes it was
+// handed. Tied to that package's error text through the peer-dependency range.
+const NEEDS_OFFSET = /need more header bytes at offset (\d+)/;
+
+// Ceiling on one read: source pixels x bands, each materialized as an f64
+// (1 << 24 samples ≈ 134 MB). Overview levels normally keep a read far under
+// this. A raster with *no* overviews has only full resolution to read from, so
+// a zoomed-out view would ask for the entire image — 45 GB of buffer and every
+// tile in the file for the raster in GeoLibre#1743. Refusing is what keeps the
+// tab alive; zooming in narrows the window until it fits.
+const MAX_WINDOW_SAMPLES = 1 << 24;
 
 proj4.defs(
   "EPSG:3857",
@@ -50,8 +71,10 @@ function tileBounds3857(z, x, y) {
   return [-OS + x * span, OS - (y + 1) * span, -OS + (x + 1) * span, OS - y * span];
 }
 
+// `b` may be null, meaning "to the end of the file" — used to pull in a
+// trailing TIFF directory without first having to learn the file's length.
 const rangeFetcher = (url) => (a, b) =>
-  fetch(url, { headers: { Range: `bytes=${a}-${b}` } })
+  fetch(url, { headers: { Range: `bytes=${a}-${b ?? ""}` } })
     .then((r) => r.arrayBuffer())
     .then((b) => new Uint8Array(b));
 
@@ -239,7 +262,8 @@ async function makeReader(source) {
   if (typeof Blob !== "undefined" && source instanceof Blob) {
     return {
       label: source.name || "(local file)",
-      range: async (a, b) => new Uint8Array(await source.slice(a, b + 1).arrayBuffer()),
+      range: async (a, b) =>
+        new Uint8Array(await (b == null ? source.slice(a) : source.slice(a, b + 1)).arrayBuffer()),
       openTiff: () => GeoTIFF.fromBlob(source),
     };
   }
@@ -259,9 +283,54 @@ async function makeReader(source) {
       : bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength);
   return {
     label: source.name || "(local file)",
-    range: (a, b) => Promise.resolve(bytes.subarray(a, Math.min(b + 1, bytes.length))),
+    range: (a, b) =>
+      Promise.resolve(bytes.subarray(a, b == null ? bytes.length : Math.min(b + 1, bytes.length))),
     openTiff: () => GeoTIFF.fromArrayBuffer(ab),
   };
+}
+
+/**
+ * Parse the TIFF header, wherever the directory happens to live.
+ *
+ * A Cloud Optimized GeoTIFF keeps every IFD at the front of the file, so the
+ * first 64 KB usually has it; grow the prefix for one with many overviews or a
+ * huge tile-offset array. A **plain** GeoTIFF, which is what GDAL and libtiff
+ * write unless asked for a COG, puts the directory *after* the pixel data,
+ * where no front prefix short of the whole file can reach it. Read where the
+ * directory actually is and pull in that region as a second window instead
+ * (GeoLibre#1743: a 74 MB raster needs 704 KB of it, not 74 MB).
+ */
+async function openHeader(range) {
+  const prefix = await range(0, HEADER_PREFIX - 1);
+  const ifd = first_ifd_offset(prefix); // throws if this is not a TIFF at all
+  if (ifd < prefix.length) {
+    for (let len = HEADER_PREFIX; ; len *= 8) {
+      try {
+        return new CogStream(len === HEADER_PREFIX ? prefix : await range(0, len - 1));
+      } catch (e) {
+        if (len >= MAX_HEADER_PREFIX) throw e;
+      }
+    }
+  }
+  // Widen a window around the directory until the parse lands.
+  let start = ifd,
+    end = ifd + HEADER_TAIL,
+    covered = 0;
+  for (;;) {
+    const tail = await range(start, end - 1);
+    try {
+      return CogStream.from_windows(prefix, start, tail);
+    } catch (e) {
+      const want = Number(NEEDS_OFFSET.exec(String(e))?.[1]);
+      const next = widenHeaderWindow(start, end, want);
+      // Retry only a miss we can act on, that we can still afford, and where the
+      // last fetch actually brought back more of the file (past the end, it does
+      // not, and growing the window forever would never fix that).
+      if (!next || tail.length <= covered || next.end - next.start > MAX_HEADER_TAIL) throw e;
+      covered = tail.length;
+      ({ start, end } = next);
+    }
+  }
 }
 
 /**
@@ -275,17 +344,7 @@ async function makeReader(source) {
 export async function openCog(source) {
   await init();
   const { range, openTiff, label } = await makeReader(source);
-  // Parse the COG header; grow the prefix and retry for large COGs whose IFDs
-  // exceed 64 KB (many overviews / huge tile-offset arrays).
-  let stream;
-  for (let len = 65536; ; len *= 8) {
-    try {
-      stream = new CogStream(await range(0, len - 1));
-      break;
-    } catch (e) {
-      if (len >= 1 << 25) throw e; // give up past ~32 MB
-    }
-  }
+  const stream = await openHeader(range);
   const gt = stream.geo_transform(); // [x0, px_w, rot, y0, rot, px_h]
   const levels = JSON.parse(stream.levels_json());
   if (!Array.isArray(levels) || levels.length === 0) {
@@ -413,6 +472,14 @@ export class CogSource {
   // planar (INTERLEAVE=BAND) COGs are read per-band via geotiff.js, which
   // whitebox's chunky-only streaming decoder can't address.
   async _assembleWindow(level, x, y, w, h, band = 0) {
+    if (w * h > MAX_WINDOW_SAMPLES) {
+      throw new Error(
+        `window ${w}x${h} on level ${level} is too large to read (limit ${MAX_WINDOW_SAMPLES} samples)` +
+          (this.levels.length === 1
+            ? "; this raster has no overviews, so add them (gdaladdo, or convert to a COG) or read a smaller area"
+            : ""),
+      );
+    }
     if (this.planar) {
       const img = await this._tiffImage(level);
       const rasters = await img.readRasters({ window: [x, y, x + w, y + h], samples: [band] });
@@ -437,6 +504,22 @@ export class CogSource {
       }
     });
     return buf;
+  }
+
+  // Say once, per source, why a zoomed-out view is blank. Repeating it for
+  // every tile in the viewport would bury the one thing worth reading.
+  _warnUnrenderable(ww, hh) {
+    if (this._warnedUnrenderable) return;
+    this._warnedUnrenderable = true;
+    const l0 = this.levels[0];
+    console.warn(
+      `cog-tiler: ${this.url} needs a ${ww}x${hh} source read at this zoom, over the ` +
+        `${MAX_WINDOW_SAMPLES}-sample limit, so nothing is drawn. ` +
+        (this.levels.length === 1
+          ? `This ${l0.width}x${l0.height} raster has no overviews: add them (gdaladdo, ` +
+            `or convert it to a COG) to see it zoomed out, or zoom in.`
+          : "Zoom in, or add coarser overviews."),
+    );
   }
 
   // Choose the overview whose source resolution is the coarsest still finer than
@@ -522,6 +605,13 @@ export class CogSource {
 
     // Assemble the needed band window(s): 1 (palette/colormap) or 3 (RGB).
     const used = rgb ? bands0.slice(0, 3) : [bands0[0]];
+    // Draw nothing rather than throw per tile: an overview-less raster is
+    // simply not renderable this far out, and MapLibre asks for a whole
+    // screenful of tiles at once. `warnUnrenderable` says so once.
+    if (ww * hh * used.length > MAX_WINDOW_SAMPLES) {
+      this._warnUnrenderable(ww, hh);
+      return null;
+    }
     const bufs = await Promise.all(used.map((b) => this._assembleWindow(level, c0, r0, ww, hh, b)));
     const pal = this.palette;
 

--- a/header-window.js
+++ b/header-window.js
@@ -1,0 +1,43 @@
+/**
+ * Byte-window arithmetic for reading a TIFF header out of a file you are only
+ * range-reading.
+ *
+ * A Cloud Optimized GeoTIFF keeps every IFD at the front of the file, so a small
+ * front prefix has the whole header. A **plain** GeoTIFF -- what GDAL and
+ * libtiff write unless asked for a COG -- puts the directory *after* the pixel
+ * data, so the header has to be read from a second window further in, and that
+ * window sometimes has to grow before it covers every tag array.
+ */
+
+/** First read of a file: enough for a typical COG's whole IFD chain. */
+export const HEADER_PREFIX = 65536;
+/** Stop growing a front-of-file prefix past this; the directory is elsewhere. */
+export const MAX_HEADER_PREFIX = 1 << 25;
+/** First slice taken around a directory that sits past the prefix. */
+export const HEADER_TAIL = 1 << 20;
+/** Widest window worth pulling back for a header. */
+export const MAX_HEADER_TAIL = 1 << 27;
+
+/**
+ * Widen the byte window `[start, end)` so it covers `want`, the offset a header
+ * parse said it still needed. Tag arrays usually follow the IFD, but one written
+ * before it puts the offset behind the window, so this grows in whichever
+ * direction the miss lies.
+ *
+ * Returns `null` when `want` is not a usable offset or already falls inside the
+ * window. Inside means the bytes were handed over and the parse failed for some
+ * other reason, or the file simply ended there -- either way a wider fetch
+ * cannot help, and retrying would only spin.
+ *
+ * @param {number} start Inclusive first byte of the current window.
+ * @param {number} end Exclusive last byte of the current window.
+ * @param {number} want Offset the parser asked for.
+ * @param {number} [pad] Extra bytes to take beyond `want`.
+ * @returns {{start: number, end: number} | null}
+ */
+export function widenHeaderWindow(start, end, want, pad = HEADER_TAIL) {
+  if (!Number.isFinite(want)) return null;
+  if (want < start) return { start: Math.max(0, want - pad), end };
+  if (want >= end) return { start, end: want + pad };
+  return null;
+}

--- a/scripts/assemble-demo.mjs
+++ b/scripts/assemble-demo.mjs
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
-// Copy the reusable module + sample into demo/ so the page (which imports
-// ./cog-tiler.js next to ./cog_tiler_wasm.js) can be served statically. The wasm
-// is built into demo/ by the `build:wasm` script.
+// Copy the reusable module, the sibling modules it imports, and the sample into
+// demo/ so the page (which imports ./cog-tiler.js next to ./cog_tiler_wasm.js)
+// can be served statically. The wasm is built into demo/ by `build:wasm`.
 import { copyFileSync } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
-copyFileSync(join(root, "cog-tiler.js"), join(root, "demo", "cog-tiler.js"));
+for (const f of ["cog-tiler.js", "sampling.js", "header-window.js"]) {
+  copyFileSync(join(root, f), join(root, "demo", f));
+}
 copyFileSync(join(root, "examples", "sample-3857-cog.tif"), join(root, "demo", "sample-3857-cog.tif"));
-console.log("assembled demo/ (cog-tiler.js + sample-3857-cog.tif)");
+console.log("assembled demo/ (cog-tiler.js + its sibling modules + sample-3857-cog.tif)");

--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -16,6 +16,7 @@ const pkgDir = process.argv[2] || join(root, "crates/cog-tiler-wasm/pkg");
 
 copyFileSync(join(root, "cog-tiler.js"), join(pkgDir, "cog-tiler.js"));
 copyFileSync(join(root, "sampling.js"), join(pkgDir, "sampling.js"));
+copyFileSync(join(root, "header-window.js"), join(pkgDir, "header-window.js"));
 copyFileSync(join(root, "cog-tiler.d.ts"), join(pkgDir, "cog-tiler.d.ts"));
 copyFileSync(join(root, "README.md"), join(pkgDir, "README.md"));
 copyFileSync(join(root, "LICENSE"), join(pkgDir, "LICENSE"));
@@ -38,6 +39,7 @@ pkg.files = Array.from(
     ...(pkg.files || []),
     "cog-tiler.js",
     "sampling.js",
+    "header-window.js",
     "cog-tiler.d.ts",
     "README.md",
     "LICENSE",
@@ -48,8 +50,10 @@ pkg.files = Array.from(
 // geotiff accepts v2 or v3: only the stable high-level API (fromUrl,
 // fromBlob, fromArrayBuffer, getImage, getGeoKeys, readRasters) is used, which
 // is unchanged across the v3 major, so the range must not block v3 consumers.
+// whitebox-wasm >= 0.6.0 for `first_ifd_offset` + `CogStream.from_windows`,
+// which is how a plain GeoTIFF's trailing directory gets read.
 pkg.peerDependencies = {
-  "whitebox-wasm": "^0.4.1",
+  "whitebox-wasm": "^0.6.0",
   proj4: "^2.15.0",
   geotiff: "^2.1.0 || ^3.0.0",
   "geotiff-geokeys-to-proj4": "^2024.4.13",

--- a/tests/header-window.test.mjs
+++ b/tests/header-window.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { HEADER_TAIL, widenHeaderWindow as widen } from '../header-window.js';
+
+// The layout that motivated this: the 74 MB Europe flood-hazard GeoTIFF from
+// GeoLibre#1743, a plain GDAL GeoTIFF whose directory sits at byte 74026916 —
+// past the pixel data, where a front-of-file prefix never reaches it.
+const IFD = 74026916;
+
+test('does not widen for an offset already inside the window', () => {
+  // The bytes were handed over and the parse still failed, so the shortfall is
+  // not about coverage. Widening here would refetch the same range forever.
+  assert.equal(widen(IFD, IFD + HEADER_TAIL, IFD + 16), null);
+  assert.equal(widen(IFD, IFD + HEADER_TAIL, IFD), null);
+});
+
+test('grows the end past an offset beyond the window', () => {
+  const end = IFD + HEADER_TAIL;
+  const want = end + 4096; // a tag array written after the first slice
+  assert.deepEqual(widen(IFD, end, want), { start: IFD, end: want + HEADER_TAIL });
+});
+
+test('moves the start back for an offset behind the window', () => {
+  // A tag array written *before* the directory: the parse asks for an offset
+  // the tail never covered, and only reaching further back can satisfy it.
+  const want = IFD - 4096;
+  assert.deepEqual(widen(IFD, IFD + HEADER_TAIL, want), {
+    start: want - HEADER_TAIL,
+    end: IFD + HEADER_TAIL,
+  });
+});
+
+test('never starts a window before the file', () => {
+  const { start } = widen(1000, 2000, 8);
+  assert.equal(start, 0);
+});
+
+test('rejects an offset it cannot act on', () => {
+  // No match in the error text leaves `want` NaN; retrying on that would be a
+  // guess, so the caller has to surface the original failure instead.
+  assert.equal(widen(IFD, IFD + HEADER_TAIL, NaN), null);
+  assert.equal(widen(IFD, IFD + HEADER_TAIL, Number('nope')), null);
+});
+
+test('honors an explicit pad', () => {
+  const end = IFD + HEADER_TAIL;
+  assert.deepEqual(widen(IFD, end, end + 10, 64), { start: IFD, end: end + 74 });
+});


### PR DESCRIPTION
Two things went wrong when a *plain* GeoTIFF -- what GDAL and libtiff write
unless you ask for a COG -- was dropped on the map.

**It would not open.** `openCog` grew a front-of-file prefix (64 KB, then x8,
giving up at 32 MB) and handed it to `CogStream`. A COG keeps every IFD at the
front so that always worked, but a plain GeoTIFF puts its directory *after* the
pixel data: on the 74 MB raster from GeoLibre#1743 it sits at byte 74026916, so
no prefix short of the whole file reaches it and the user got
`header: I/O error: failed to fill whole buffer`.

Read `first_ifd_offset` from the first 64 KB instead, and when the directory is
past the prefix, pull in a window around it (`CogStream.from_windows`, new in
whitebox-wasm 0.6.0) rather than growing the front. That file now opens from
704 KB, 0.94% of it. If a tag array sits before the directory the parse names
the offset it wants and the window widens toward it -- `widenHeaderWindow`, in
its own module so it is unit-testable without loading the wasm.

**Once open, it wedged the tab.** A plain GeoTIFF usually carries no overviews,
so full resolution is the only thing to read from, and a zoomed-out tile asked
for the entire image: for that 110162x51992 raster a 54001x30641 read, a 45 GB
f64 buffer and all ~88000 tiles. The tab climbed to 14 GB and stopped
responding. Reads are now capped at 1<<24 samples: over that a tile renders
blank and one console warning explains why and what to do (gdaladdo, or zoom
in). The raster still opens, reports its bounds and CRS, and draws normally
once the window fits.

Range readers take a null end meaning "to the end of the file", so the tail
read needs no HEAD request for the length.

Also copy `sampling.js` (and the new `header-window.js`) into the demo and the
Pages site. Only `cog-tiler.js` was being copied, so both its sibling imports
404'd there.

Reported downstream as opengeos/GeoLibre#1743.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening plain, non-COG GeoTIFF files.
  * Added support for TIFF metadata stored beyond the initial file range.
  * Added open-ended data reads across supported sources.
  * Added safer handling for large zoomed-out views, returning blank tiles when rendering limits are exceeded.
  * Added a utility for expanding TIFF header read ranges.

* **Documentation**
  * Documented plain GeoTIFF behavior, overview limitations, header reads, and zoomed-out rendering limits.

* **Bug Fixes**
  * Improved TIFF header parsing and range handling for files with distant directories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->