### PR TITLE
fix: accept current GeoTIFF geokey peer

### DIFF
--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -52,7 +52,7 @@ pkg.peerDependencies = {
   "whitebox-wasm": "^0.4.1",
   proj4: "^2.15.0",
   geotiff: "^2.1.0 || ^3.0.0",
-  "geotiff-geokeys-to-proj4": "^2024.4.13",
+  "geotiff-geokeys-to-proj4": "^2024.4.13 || ^2026.8.16",
 };
 pkg.keywords = [
   "cog", "geotiff", "tiler", "webassembly", "wasm",


### PR DESCRIPTION
GeoLibre uses geotiff-geokeys-to-proj4 2026.8.16, which remains API-compatible with cog-tiler-wasm but falls outside the package's 2024-only peer range. Accept both supported release lines so npm can install cog-tiler-wasm 0.3.2 without `--force`.

Verified with `npm test`.