### PR TITLE
fix: allow Whitebox WASM 0.5 peer

### DIFF
--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -49,7 +49,7 @@ pkg.files = Array.from(
 // fromBlob, fromArrayBuffer, getImage, getGeoKeys, readRasters) is used, which
 // is unchanged across the v3 major, so the range must not block v3 consumers.
 pkg.peerDependencies = {
-  "whitebox-wasm": "^0.4.1",
+  "whitebox-wasm": "^0.4.1 || ^0.5.1",
   proj4: "^2.15.0",
   geotiff: "^2.1.0 || ^3.0.0",
   "geotiff-geokeys-to-proj4": "^2024.4.13 || ^2026.8.16",


### PR DESCRIPTION
Expand the generated package peer range to include `whitebox-wasm` 0.5.x, which is API-compatible and currently used by GeoLibre. This lets consumers install the big-endian COG fix without bypassing npm peer dependency validation.