### PR TITLE
fix: increase raster histogram resolution

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,7 @@ jobs:
             --out-dir "$GITHUB_WORKSPACE/site"
           cp demo/index.html site/index.html
           cp cog-tiler.js site/cog-tiler.js
+          cp statistics.js site/statistics.js
           cp examples/sample-3857-cog.tif site/sample-3857-cog.tif
           rm -f site/.gitignore
           # Cache-bust the loader + module + wasm together so returning visitors

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -26,6 +26,7 @@ import proj4 from "proj4";
 import * as GeoTIFF from "geotiff";
 import geokeysToProj4 from "geotiff-geokeys-to-proj4";
 import { sampleWindowBilinear } from "./sampling.js";
+import { computeStats } from "./statistics.js";
 
 const OS = 20037508.342789244; // Web Mercator half-extent (m)
 const TILE = 256; // output tile size (px)
@@ -63,44 +64,6 @@ function dtypeOf(lv) {
   if (f === "uint" || f.includes("unsigned")) return "uint" + b;
   if (f === "int" || f.includes("signed")) return "int" + b;
   return (f || "uint") + b;
-}
-
-/** Min/max/mean/std/count/valid_percent/percentiles/histogram for a band buffer. */
-function computeStats(buf, nodata) {
-  let min = Infinity, max = -Infinity, sum = 0, sumsq = 0;
-  const valid = [];
-  for (let i = 0; i < buf.length; i++) {
-    const v = buf[i];
-    if (Number.isNaN(v)) continue;
-    if (nodata != null && v === nodata) continue;
-    if (v < min) min = v;
-    if (v > max) max = v;
-    sum += v;
-    sumsq += v * v;
-    valid.push(v);
-  }
-  const count = valid.length;
-  if (count === 0) return { count: 0, valid_percent: 0 };
-  const mean = sum / count;
-  const std = Math.sqrt(Math.max(0, sumsq / count - mean * mean));
-  valid.sort((a, b) => a - b);
-  const pct = (p) => valid[Math.min(count - 1, Math.floor((p / 100) * count))];
-  const bins = 10, span = max - min || 1, hist = new Array(bins).fill(0);
-  for (const v of valid) {
-    let k = Math.floor(((v - min) / span) * bins);
-    if (k >= bins) k = bins - 1;
-    if (k < 0) k = 0;
-    hist[k]++;
-  }
-  const edges = Array.from({ length: bins + 1 }, (_, i) => min + (span * i) / bins);
-  return {
-    min, max, mean, std, count,
-    valid_percent: (count / buf.length) * 100,
-    median: pct(50),
-    percentile_2: pct(2),
-    percentile_98: pct(98),
-    histogram: [hist, edges],
-  };
 }
 
 /** Transfer curve for a rescaled value in 0..1: stretch then gamma (mirrors the

--- a/scripts/assemble-demo.mjs
+++ b/scripts/assemble-demo.mjs
@@ -8,5 +8,6 @@ import { fileURLToPath } from "node:url";
 
 const root = join(fileURLToPath(new URL(".", import.meta.url)), "..");
 copyFileSync(join(root, "cog-tiler.js"), join(root, "demo", "cog-tiler.js"));
+copyFileSync(join(root, "statistics.js"), join(root, "demo", "statistics.js"));
 copyFileSync(join(root, "examples", "sample-3857-cog.tif"), join(root, "demo", "sample-3857-cog.tif"));
-console.log("assembled demo/ (cog-tiler.js + sample-3857-cog.tif)");
+console.log("assembled demo/ (cog-tiler.js + statistics.js + sample-3857-cog.tif)");

--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -16,6 +16,7 @@ const pkgDir = process.argv[2] || join(root, "crates/cog-tiler-wasm/pkg");
 
 copyFileSync(join(root, "cog-tiler.js"), join(pkgDir, "cog-tiler.js"));
 copyFileSync(join(root, "sampling.js"), join(pkgDir, "sampling.js"));
+copyFileSync(join(root, "statistics.js"), join(pkgDir, "statistics.js"));
 copyFileSync(join(root, "cog-tiler.d.ts"), join(pkgDir, "cog-tiler.d.ts"));
 copyFileSync(join(root, "README.md"), join(pkgDir, "README.md"));
 copyFileSync(join(root, "LICENSE"), join(pkgDir, "LICENSE"));
@@ -38,6 +39,7 @@ pkg.files = Array.from(
     ...(pkg.files || []),
     "cog-tiler.js",
     "sampling.js",
+    "statistics.js",
     "cog-tiler.d.ts",
     "README.md",
     "LICENSE",

--- a/statistics.js
+++ b/statistics.js
@@ -1,0 +1,44 @@
+/** Number of histogram buckets exposed through the TiTiler-style statistics API. */
+export const HISTOGRAM_BINS = 128;
+
+/** Min/max/mean/std/count/valid_percent/percentiles/histogram for a band buffer. */
+export function computeStats(buf, nodata) {
+  let min = Infinity, max = -Infinity, sum = 0, sumsq = 0;
+  const valid = [];
+  for (let i = 0; i < buf.length; i++) {
+    const v = buf[i];
+    if (Number.isNaN(v)) continue;
+    if (nodata != null && v === nodata) continue;
+    if (v < min) min = v;
+    if (v > max) max = v;
+    sum += v;
+    sumsq += v * v;
+    valid.push(v);
+  }
+  const count = valid.length;
+  if (count === 0) return { count: 0, valid_percent: 0 };
+  const mean = sum / count;
+  const std = Math.sqrt(Math.max(0, sumsq / count - mean * mean));
+  valid.sort((a, b) => a - b);
+  const pct = (p) => valid[Math.min(count - 1, Math.floor((p / 100) * count))];
+  const span = max - min || 1;
+  const histogram = new Array(HISTOGRAM_BINS).fill(0);
+  for (const v of valid) {
+    let bin = Math.floor(((v - min) / span) * HISTOGRAM_BINS);
+    if (bin >= HISTOGRAM_BINS) bin = HISTOGRAM_BINS - 1;
+    if (bin < 0) bin = 0;
+    histogram[bin]++;
+  }
+  const edges = Array.from(
+    { length: HISTOGRAM_BINS + 1 },
+    (_, i) => min + (span * i) / HISTOGRAM_BINS,
+  );
+  return {
+    min, max, mean, std, count,
+    valid_percent: (count / buf.length) * 100,
+    median: pct(50),
+    percentile_2: pct(2),
+    percentile_98: pct(98),
+    histogram: [histogram, edges],
+  };
+}

--- a/tests/statistics.test.mjs
+++ b/tests/statistics.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { computeStats, HISTOGRAM_BINS } from '../statistics.js';
+
+test('returns the full histogram resolution expected by raster controls', () => {
+  const stats = computeStats(Float64Array.from({ length: 256 }, (_, i) => i), undefined);
+  const [counts, edges] = stats.histogram;
+
+  assert.equal(counts.length, HISTOGRAM_BINS);
+  assert.equal(edges.length, HISTOGRAM_BINS + 1);
+  assert.equal(counts.reduce((sum, count) => sum + count, 0), 256);
+  assert.ok(counts.every((count) => count === 2));
+});
+
+test('categorical values occupy bins that map back to their palette indices', () => {
+  const classes = [11, 21, 22, 23, 24, 31, 41, 42, 43, 52, 71, 81, 82, 90, 95];
+  const stats = computeStats(Uint8Array.from(classes), undefined);
+  const [counts] = stats.histogram;
+  const binWidth = (stats.max - stats.min) / counts.length;
+  const recovered = new Set();
+
+  for (let i = 0; i < counts.length; i++) {
+    if (counts[i] === 0) continue;
+    const low = Math.ceil(stats.min + i * binWidth);
+    const high = Math.floor(
+      i === counts.length - 1 ? stats.max : stats.min + (i + 1) * binWidth - 1e-9,
+    );
+    for (let value = low; value <= high; value++) recovered.add(value);
+  }
+
+  assert.deepEqual([...recovered], classes);
+});
+
+test('excludes nodata and NaN samples from statistics', () => {
+  const stats = computeStats(Float64Array.from([1, 2, -9999, NaN]), -9999);
+
+  assert.equal(stats.count, 2);
+  assert.equal(stats.valid_percent, 50);
+  assert.equal(stats.min, 1);
+  assert.equal(stats.max, 2);
+  assert.equal(stats.histogram[0].reduce((sum, count) => sum + count, 0), 2);
+});


### PR DESCRIPTION
## Summary

- generate 128 histogram bins for raster statistics instead of 10
- keep the statistics helper independently testable and include it in the npm package
- verify continuous, categorical, and nodata inputs

## Why

Raster styling controls consume 128-bin statistics. The previous 10-bin output produced a sparse rescale chart after adaptation and prevented categorical palette previews from identifying the correct class indices.

## Testing

- `npm test`
- `npm run build:pkg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved raster statistics behavior, including handling of nodata and invalid values.
  * Continued providing per-band metrics such as mean, standard deviation, percentiles, and histograms.
* **Tests**
  * Added coverage for histogram generation, categorical values, and exclusion of nodata and NaN samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->