### PR TITLE
fix: decode LERC and ZSTD COGs through geotiff.js and reject unsupported codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,18 @@ It uses the `lerc`, `pako`, and `zstddec` packages geotiff.js already depends
 on (declared as optional peers); if they cannot be resolved, the built-in
 decoder stays in place.
 
+lerc finds its `lerc-wasm.wasm` relative to its own module URL, which bundlers
+that hash assets or pre-bundle dependencies do not always rewrite. If the
+console reports a wasm compile error (`expected magic word 00 61 73 6d`), hand
+the decoder the URL your bundler resolves for the asset before the first LERC
+COG opens:
+
+```js
+import lercWasmUrl from "lerc/lerc-wasm.wasm?url"; // Vite
+import { configureLercDecoder } from "cog-tiler-wasm";
+configureLercDecoder({ wasmUrl: lercWasmUrl });
+```
+
 ## Roadmap
 
 - **TiTiler COG API parity** - done: `info`, `info.geojson`, `tilejson`,

--- a/README.md
+++ b/README.md
@@ -203,6 +203,24 @@ A `256*256*4` RGBA tile. `pixels` is the decoded row-major `f64` window;
 `colormap` is `"viridis" | "magma" | "terrain" | "gray"`. Empty windows render
 fully transparent.
 
+## Compression
+
+Tiles are decoded by whitebox-wasm's pure-Rust codec stack (None, LZW, Deflate,
+PackBits, JPEG, WebP, JPEG-XL) or, for the codecs it lacks, by geotiff.js (LERC
+in all three `LERC`/`LERC_DEFLATE`/`LERC_ZSTD` modes, and ZSTD). `openCog`
+picks the decoder from the header and **rejects** a COG whose compression
+neither can read (LZMA, JPEG 2000, CCITT, ...), so hosts can show the error
+instead of a silently blank layer. `compressionDecoder(levelInfo.compression)`
+exposes the same decision.
+
+LERC tiles carry a validity mask that geotiff.js's built-in decoder discards
+(nodata pixels would read as 0). `openCog` registers a mask-aware replacement
+([`lerc-decoder.js`](lerc-decoder.js)) that fills masked pixels with the
+dataset's `GDAL_NODATA` value, or NaN for floating-point rasters without one.
+It uses the `lerc`, `pako`, and `zstddec` packages geotiff.js already depends
+on (declared as optional peers); if they cannot be resolved, the built-in
+decoder stays in place.
+
 ## Roadmap
 
 - **TiTiler COG API parity** - done: `info`, `info.geojson`, `tilejson`,
@@ -212,7 +230,9 @@ fully transparent.
 - **Warping** of projected/4326 sources and **paletted/categorical** rendering
   are done in [`cog-tiler.js`](cog-tiler.js) (proj4js + geotiff.js). **Planar**
   (`INTERLEAVE=BAND`) multi-band COGs are read per-band via geotiff.js too, since
-  whitebox-wasm's streaming decoder is chunky-only. Next: planar support
+  whitebox-wasm's streaming decoder is chunky-only, as are **LERC** and **ZSTD**
+  COGs, which the wasm codec stack lacks (see [Compression](#compression)).
+  Next: planar support
   **upstream in `whitebox-wasm`** (and exposing its proj string + color table) to
   drop the geotiff.js dependency, then move the warp into the Rust crate
   (`proj4rs`).

--- a/README.md
+++ b/README.md
@@ -211,7 +211,12 @@ in all three `LERC`/`LERC_DEFLATE`/`LERC_ZSTD` modes, and ZSTD). `openCog`
 picks the decoder from the header and **rejects** a COG whose compression
 neither can read (LZMA, JPEG 2000, CCITT, ...), so hosts can show the error
 instead of a silently blank layer. `compressionDecoder(levelInfo.compression)`
-exposes the same decision.
+exposes the same decision. Overviews may use a different codec than the base
+image (GDAL's `OVERVIEW_COMPRESS`); the decision is made per level.
+
+With geotiff.js 2.x, direct ZSTD is rejected at open (2.x has no decoder for
+TIFF code 50000) and LERC renders without its validity mask; geotiff.js 3.x
+supports both fully.
 
 LERC tiles carry a validity mask that geotiff.js's built-in decoder discards
 (nodata pixels would read as 0). `openCog` registers a mask-aware replacement

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -145,6 +145,16 @@ export declare function parseCompression(compression: string | undefined): { cod
 /** The message `openCog` rejects with for a codec no decoder handles. */
 export declare function unsupportedCompressionMessage(compression: string | undefined): string;
 
+/**
+ * Where lerc's `lerc-wasm.wasm` is served from, for the mask-aware LERC
+ * decoder. lerc resolves it relative to its own module URL, which bundlers
+ * that hash assets or pre-bundle dependencies do not always rewrite; pass the
+ * URL your bundler resolves for the asset (Vite:
+ * `import lercWasmUrl from "lerc/lerc-wasm.wasm?url"`). Call before the first
+ * LERC COG opens. `null`/omitted restores lerc's own resolution.
+ */
+export declare function configureLercDecoder(options?: { wasmUrl?: string | URL | null }): void;
+
 /** Encode an RGBA buffer to PNG bytes (browser; uses OffscreenCanvas).
  *  Defaults to 256x256 when `width`/`height` are omitted. */
 export declare function rgbaToPng(

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -140,13 +140,21 @@ export declare function openCog(source: string | ArrayBuffer | Uint8Array | Blob
  * Which decoder reads tiles in a given compression, as reported by
  * `LevelInfo.compression`: `"wasm"` (whitebox-wasm), `"geotiff"` (geotiff.js,
  * used for LERC and ZSTD), or `null` when neither can. `openCog` rejects with
- * {@link unsupportedCompressionMessage} for the `null` case.
+ * {@link unsupportedCompressionMessage} for the `null` case. `directZstd`
+ * (default true) says whether the installed geotiff.js registers TIFF code
+ * 50000: 3.x does, 2.x does not.
  */
-export declare function compressionDecoder(compression: string | undefined): "wasm" | "geotiff" | null;
+export declare function compressionDecoder(
+  compression: string | undefined,
+  options?: { directZstd?: boolean },
+): "wasm" | "geotiff" | null;
 /** Parse a `LevelInfo.compression` string into its TIFF code and a readable name. */
 export declare function parseCompression(compression: string | undefined): { code: number | null; name: string };
 /** The message `openCog` rejects with for a codec no decoder handles. */
-export declare function unsupportedCompressionMessage(compression: string | undefined): string;
+export declare function unsupportedCompressionMessage(
+  compression: string | undefined,
+  options?: { directZstd?: boolean },
+): string;
 
 /**
  * Where lerc's `lerc-wasm.wasm` is served from, for the mask-aware LERC

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -62,10 +62,13 @@ export declare class CogSource {
   readonly boundsLonLat: number[];
   /** True when the band is paletted (categorical) and rendered via its table. */
   readonly hasPalette: boolean;
-  /** True when pixels are read through geotiff.js rather than the wasm
-   * streaming decoder: planar layouts, big-endian samples, and codecs the
-   * wasm decoder lacks (LERC, ZSTD). */
+  /** True when some level's pixels are read through geotiff.js rather than
+   * the wasm streaming decoder: planar layouts, big-endian samples, and codecs
+   * the wasm decoder lacks (LERC, ZSTD). */
   readonly readsViaGeoTiff: boolean;
+  /** Whether `level` is read through geotiff.js. Overviews may be compressed
+   * differently from the base image (GDAL's OVERVIEW_COMPRESS). */
+  levelReadsViaGeoTiff(level: number): boolean;
   /** Render an XYZ tile to a 256x256 RGBA buffer, or null if empty. (Paletted
    * tiles are a `Uint8ClampedArray`; continuous tiles are the wasm `render()`
    * `Uint8Array`.) */

--- a/cog-tiler.d.ts
+++ b/cog-tiler.d.ts
@@ -62,6 +62,10 @@ export declare class CogSource {
   readonly boundsLonLat: number[];
   /** True when the band is paletted (categorical) and rendered via its table. */
   readonly hasPalette: boolean;
+  /** True when pixels are read through geotiff.js rather than the wasm
+   * streaming decoder: planar layouts, big-endian samples, and codecs the
+   * wasm decoder lacks (LERC, ZSTD). */
+  readonly readsViaGeoTiff: boolean;
   /** Render an XYZ tile to a 256x256 RGBA buffer, or null if empty. (Paletted
    * tiles are a `Uint8ClampedArray`; continuous tiles are the wasm `render()`
    * `Uint8Array`.) */
@@ -128,6 +132,18 @@ export declare function init(): Promise<unknown>;
  * multi-GB local rasters never load whole), or in-memory bytes.
  */
 export declare function openCog(source: string | ArrayBuffer | Uint8Array | Blob): Promise<CogSource>;
+
+/**
+ * Which decoder reads tiles in a given compression, as reported by
+ * `LevelInfo.compression`: `"wasm"` (whitebox-wasm), `"geotiff"` (geotiff.js,
+ * used for LERC and ZSTD), or `null` when neither can. `openCog` rejects with
+ * {@link unsupportedCompressionMessage} for the `null` case.
+ */
+export declare function compressionDecoder(compression: string | undefined): "wasm" | "geotiff" | null;
+/** Parse a `LevelInfo.compression` string into its TIFF code and a readable name. */
+export declare function parseCompression(compression: string | undefined): { code: number | null; name: string };
+/** The message `openCog` rejects with for a codec no decoder handles. */
+export declare function unsupportedCompressionMessage(compression: string | undefined): string;
 
 /** Encode an RGBA buffer to PNG bytes (browser; uses OffscreenCanvas).
  *  Defaults to 256x256 when `width`/`height` are omitted. */

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -45,6 +45,13 @@ proj4.defs(
 );
 
 let _ready = null;
+const warned = new Set();
+function warnOnce(key, message) {
+  if (warned.has(key)) return;
+  warned.add(key);
+  console.warn(message);
+}
+
 /** Initialize the wasm modules (idempotent). Resolve this before `openCog`. */
 export function init() {
   if (!_ready) _ready = Promise.all([initWhitebox(), initTiler()]);
@@ -270,10 +277,15 @@ export async function openCog(source) {
   // failure only yields transparent tiles and a silently blank map. Every
   // level is checked because GDAL can compress overviews differently from the
   // base image (OVERVIEW_COMPRESS), so the decoder is chosen per level.
-  const decoders = levels.map((lv) => compressionDecoder(lv.compression));
+  // geotiff.js 3.x registers direct ZSTD (50000) and hands decoders typed
+  // parameters (which the mask-aware LERC decoder relies on); 2.x does
+  // neither. 3.x is the major that started exporting ImageFileDirectory.
+  const geotiffV3 = typeof GeoTIFF.ImageFileDirectory === "function";
+  const codecOptions = { directZstd: geotiffV3 };
+  const decoders = levels.map((lv) => compressionDecoder(lv.compression, codecOptions));
   const unsupported = decoders.indexOf(null);
   if (unsupported >= 0) {
-    throw new Error(unsupportedCompressionMessage(levels[unsupported].compression));
+    throw new Error(unsupportedCompressionMessage(levels[unsupported].compression, codecOptions));
   }
   // Open the GeoTIFF with geotiff.js when we need the CRS (non-3857), to check
   // the planar config (multi-band), or to decode tiles of some level.
@@ -283,9 +295,12 @@ export async function openCog(source) {
   const multiBand = levels[0].bands > 1;
   const geotiffCodec = decoders.some((d) => d === "geotiff");
   // geotiff.js's own LERC decoder drops the validity mask (nodata reads as 0);
-  // swap in the mask-aware one before the first tile is decoded.
+  // swap in the mask-aware one before the first tile is decoded. It targets
+  // the 3.x decoder contract, so on 2.x the built-in decoder stays (LERC still
+  // renders, masked pixels read as 0).
   if (levels.some((lv) => parseCompression(lv.compression).code === LERC_COMPRESSION)) {
-    await registerMaskedLercDecoder();
+    if (geotiffV3) await registerMaskedLercDecoder();
+    else warnOnce("lerc-mask-v2", "[cog-tiler] geotiff.js 2.x: LERC validity mask not applied; upgrade to geotiff 3.x for correct nodata.");
   }
   let tiff = null, img = null, planar = false;
   if (stream.epsg !== 3857 || multiBand || bigEndian || geotiffCodec) {

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -25,6 +25,10 @@ import initTiler, { colorize, colormap_names } from "./cog_tiler_wasm.js";
 import proj4 from "proj4";
 import * as GeoTIFF from "geotiff";
 import geokeysToProj4 from "geotiff-geokeys-to-proj4";
+import { compressionDecoder, parseCompression, unsupportedCompressionMessage } from "./compression.js";
+import { LERC_COMPRESSION, registerMaskedLercDecoder } from "./lerc-decoder.js";
+
+export { compressionDecoder, parseCompression, unsupportedCompressionMessage } from "./compression.js";
 import { sampleWindowBilinear } from "./sampling.js";
 import { computeStats } from "./statistics.js";
 
@@ -259,13 +263,25 @@ export async function openCog(source) {
   if (!Array.isArray(levels) || levels.length === 0) {
     throw new Error("levels_json() returned no levels");
   }
-  // Open the GeoTIFF with geotiff.js when we need the CRS (non-3857) or to check
-  // the planar config (multi-band). whitebox-wasm's streaming decoder is
-  // chunky-only, so planar (INTERLEAVE=BAND) multi-band COGs are read per-band
+  // Fail at open time, not tile by tile, when no decoder can read the codec:
+  // hosts surface an openCog rejection as a layer error, whereas a tile decode
+  // failure only yields transparent tiles and a silently blank map.
+  const decoder = compressionDecoder(levels[0].compression);
+  if (!decoder) throw new Error(unsupportedCompressionMessage(levels[0].compression));
+  // Open the GeoTIFF with geotiff.js when we need the CRS (non-3857), to check
+  // the planar config (multi-band), or to decode the tiles themselves.
+  // whitebox-wasm's streaming decoder is chunky-only and lacks LERC/ZSTD, so
+  // planar (INTERLEAVE=BAND) multi-band COGs and those codecs are read
   // through geotiff.js instead (see _assembleWindow / point).
   const multiBand = levels[0].bands > 1;
+  const geotiffCodec = decoder === "geotiff";
+  // geotiff.js's own LERC decoder drops the validity mask (nodata reads as 0);
+  // swap in the mask-aware one before the first tile is decoded.
+  if (geotiffCodec && parseCompression(levels[0].compression).code === LERC_COMPRESSION) {
+    await registerMaskedLercDecoder();
+  }
   let tiff = null, img = null, planar = false;
-  if (stream.epsg !== 3857 || multiBand || bigEndian) {
+  if (stream.epsg !== 3857 || multiBand || bigEndian || geotiffCodec) {
     tiff = await openTiff();
     img = await tiff.getImage();
     planar = multiBand && (await readTiffTag(img, "PlanarConfiguration")) === 2;
@@ -285,6 +301,7 @@ export async function openCog(source) {
     tiff,
     planar,
     bigEndian,
+    geotiffCodec,
   };
 
   if (stream.epsg === 3857) {
@@ -349,6 +366,13 @@ export class CogSource {
     return !!this.palette;
   }
 
+  /** True when pixels are read through geotiff.js rather than the wasm
+   * streaming decoder: planar layouts, big-endian samples, and codecs the wasm
+   * decoder lacks (LERC, ZSTD). */
+  get readsViaGeoTiff() {
+    return !!(this.planar || this.bigEndian || this.geotiffCodec);
+  }
+
   /** Render an XYZ tile to a 256x256 RGBA buffer, or null if empty. */
   async renderTileRGBA(z, x, y, opts = {}) {
     return this._renderExtent(tileBounds3857(z, x, y), TILE, TILE, opts);
@@ -393,11 +417,12 @@ export class CogSource {
 
   // Fetch + decode band `band` (0-based) over a level pixel window into a
   // row-major buffer. Chunky COGs go through whitebox (cached, NaN for gaps);
-  // Planar (INTERLEAVE=BAND) and big-endian COGs are read per-band via
-  // geotiff.js. Whitebox's streaming decoder cannot address planar tiles and
-  // currently interprets multi-byte tile samples as little-endian.
+  // Planar (INTERLEAVE=BAND), big-endian, and LERC/ZSTD COGs are read per-band
+  // via geotiff.js. Whitebox's streaming decoder cannot address planar tiles,
+  // currently interprets multi-byte tile samples as little-endian, and has no
+  // LERC or ZSTD codec.
   async _assembleWindow(level, x, y, w, h, band = 0) {
-    if (this.planar || this.bigEndian) {
+    if (this.readsViaGeoTiff) {
       const img = await this._tiffImage(level);
       const rasters = await img.readRasters({ window: [x, y, x + w, y + h], samples: [band] });
       return rasters[0]; // typed array, length w*h, row-major
@@ -644,8 +669,9 @@ export class CogSource {
     }
     const bands = bidx ? bidx.map((b) => b - 1) : Array.from({ length: l0.bands }, (_, i) => i);
     let values;
-    if (this.planar) {
-      // Planar: whitebox can't address bands 1..n; read the pixel via geotiff.js.
+    if (this.readsViaGeoTiff) {
+      // Same decoder as _assembleWindow: whitebox can't address planar bands,
+      // reads big-endian samples as little-endian, and lacks LERC/ZSTD.
       const img = await this._tiffImage(0);
       const r = await img.readRasters({ window: [col, row, col + 1, row + 1], samples: bands });
       values = r.map((b) => b[0]);

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -265,21 +265,26 @@ export async function openCog(source) {
   if (!Array.isArray(levels) || levels.length === 0) {
     throw new Error("levels_json() returned no levels");
   }
-  // Fail at open time, not tile by tile, when no decoder can read the codec:
+  // Fail at open time, not tile by tile, when no decoder can read a codec:
   // hosts surface an openCog rejection as a layer error, whereas a tile decode
-  // failure only yields transparent tiles and a silently blank map.
-  const decoder = compressionDecoder(levels[0].compression);
-  if (!decoder) throw new Error(unsupportedCompressionMessage(levels[0].compression));
+  // failure only yields transparent tiles and a silently blank map. Every
+  // level is checked because GDAL can compress overviews differently from the
+  // base image (OVERVIEW_COMPRESS), so the decoder is chosen per level.
+  const decoders = levels.map((lv) => compressionDecoder(lv.compression));
+  const unsupported = decoders.indexOf(null);
+  if (unsupported >= 0) {
+    throw new Error(unsupportedCompressionMessage(levels[unsupported].compression));
+  }
   // Open the GeoTIFF with geotiff.js when we need the CRS (non-3857), to check
-  // the planar config (multi-band), or to decode the tiles themselves.
+  // the planar config (multi-band), or to decode tiles of some level.
   // whitebox-wasm's streaming decoder is chunky-only and lacks LERC/ZSTD, so
   // planar (INTERLEAVE=BAND) multi-band COGs and those codecs are read
   // through geotiff.js instead (see _assembleWindow / point).
   const multiBand = levels[0].bands > 1;
-  const geotiffCodec = decoder === "geotiff";
+  const geotiffCodec = decoders.some((d) => d === "geotiff");
   // geotiff.js's own LERC decoder drops the validity mask (nodata reads as 0);
   // swap in the mask-aware one before the first tile is decoded.
-  if (geotiffCodec && parseCompression(levels[0].compression).code === LERC_COMPRESSION) {
+  if (levels.some((lv) => parseCompression(lv.compression).code === LERC_COMPRESSION)) {
     await registerMaskedLercDecoder();
   }
   let tiff = null, img = null, planar = false;
@@ -304,6 +309,7 @@ export async function openCog(source) {
     planar,
     bigEndian,
     geotiffCodec,
+    decoders,
   };
 
   if (stream.epsg === 3857) {
@@ -368,11 +374,18 @@ export class CogSource {
     return !!this.palette;
   }
 
-  /** True when pixels are read through geotiff.js rather than the wasm
-   * streaming decoder: planar layouts, big-endian samples, and codecs the wasm
-   * decoder lacks (LERC, ZSTD). */
+  /** True when some level's pixels are read through geotiff.js rather than
+   * the wasm streaming decoder: planar layouts, big-endian samples, and codecs
+   * the wasm decoder lacks (LERC, ZSTD). Per-level: {@link levelReadsViaGeoTiff}. */
   get readsViaGeoTiff() {
     return !!(this.planar || this.bigEndian || this.geotiffCodec);
+  }
+
+  /** Whether `level` is read through geotiff.js. Overviews may be compressed
+   * differently from the base image (GDAL's OVERVIEW_COMPRESS), so the codec
+   * decision is per level; planar and big-endian apply to every level. */
+  levelReadsViaGeoTiff(level) {
+    return !!(this.planar || this.bigEndian || this.decoders?.[level] === "geotiff");
   }
 
   /** Render an XYZ tile to a 256x256 RGBA buffer, or null if empty. */
@@ -424,7 +437,7 @@ export class CogSource {
   // currently interprets multi-byte tile samples as little-endian, and has no
   // LERC or ZSTD codec.
   async _assembleWindow(level, x, y, w, h, band = 0) {
-    if (this.readsViaGeoTiff) {
+    if (this.levelReadsViaGeoTiff(level)) {
       const img = await this._tiffImage(level);
       const rasters = await img.readRasters({ window: [x, y, x + w, y + h], samples: [band] });
       return rasters[0]; // typed array, length w*h, row-major
@@ -671,7 +684,7 @@ export class CogSource {
     }
     const bands = bidx ? bidx.map((b) => b - 1) : Array.from({ length: l0.bands }, (_, i) => i);
     let values;
-    if (this.readsViaGeoTiff) {
+    if (this.levelReadsViaGeoTiff(0)) {
       // Same decoder as _assembleWindow: whitebox can't address planar bands,
       // reads big-endian samples as little-endian, and lacks LERC/ZSTD.
       const img = await this._tiffImage(0);

--- a/cog-tiler.js
+++ b/cog-tiler.js
@@ -28,6 +28,8 @@ import geokeysToProj4 from "geotiff-geokeys-to-proj4";
 import { compressionDecoder, parseCompression, unsupportedCompressionMessage } from "./compression.js";
 import { LERC_COMPRESSION, registerMaskedLercDecoder } from "./lerc-decoder.js";
 
+export { configureLercDecoder } from "./lerc-decoder.js";
+
 export { compressionDecoder, parseCompression, unsupportedCompressionMessage } from "./compression.js";
 import { sampleWindowBilinear } from "./sampling.js";
 import { computeStats } from "./statistics.js";

--- a/compression.js
+++ b/compression.js
@@ -1,0 +1,90 @@
+// TIFF compression support for the two decoders cog-tiler can read tiles with.
+//
+// whitebox-wasm reports a COG's compression as the Debug rendering of its Rust
+// enum: a bare variant name for the codecs it knows about ("Deflate", "Jpeg",
+// "JpegXl", ...) and `Other(<tiff code>)` for everything else, including LERC
+// (34887) and ZSTD (50000). geotiff.js decodes those two (and the classic
+// codecs) but not WebP/JPEG-XL, so the two decoders complement each other.
+// This module is dependency-free so it can be unit-tested under Node.
+
+/** TIFF compression tag values (`Compression`, tag 259). */
+const TIFF_CODE = {
+  None: 1,
+  Huffman: 2,
+  Lzw: 5,
+  OldJpeg: 6,
+  Jpeg: 7,
+  Deflate: 8,
+  PackBits: 32773,
+  WebP: 50001,
+  JpegXl: 50002,
+};
+
+/** Codecs whitebox-wasm's streaming decoder decompresses (by variant name). */
+const WASM_VARIANTS = new Set(["None", "Lzw", "Deflate", "PackBits", "OldJpeg", "Jpeg", "WebP", "JpegXl"]);
+
+/** Codecs geotiff.js decodes (by TIFF code), per its compression registry. */
+const GEOTIFF_CODES = new Set([1, 5, 6, 7, 8, 32946, 32773, 34887, 50000, 50001]);
+
+/** Human-readable names for TIFF compression codes seen in the wild. */
+const CODE_NAMES = new Map([
+  [1, "None"],
+  [2, "CCITT Huffman"],
+  [3, "CCITT T.4"],
+  [4, "CCITT T.6"],
+  [5, "LZW"],
+  [6, "JPEG (old-style)"],
+  [7, "JPEG"],
+  [8, "Deflate"],
+  [32773, "PackBits"],
+  [32946, "Deflate"],
+  [33003, "JPEG 2000 (Aperio YCbCr)"],
+  [33005, "JPEG 2000 (Aperio RGB)"],
+  [34661, "JBIG"],
+  [34712, "JPEG 2000"],
+  [34887, "LERC"],
+  [34925, "LZMA"],
+  [50000, "ZSTD"],
+  [50001, "WebP"],
+  [50002, "JPEG-XL"],
+  [52546, "JPEG-XL (DNG 1.7 code)"],
+]);
+
+/**
+ * Parse whitebox-wasm's compression string into `{ code, name }`.
+ * `code` is the TIFF tag value (or null when the string is unrecognized) and
+ * `name` a human-readable codec label.
+ */
+export function parseCompression(compression) {
+  const s = String(compression ?? "").trim();
+  const other = s.match(/^Other\((\d+)\)$/);
+  if (other) {
+    const code = Number(other[1]);
+    return { code, name: CODE_NAMES.get(code) ?? `TIFF compression ${code}` };
+  }
+  if (Object.prototype.hasOwnProperty.call(TIFF_CODE, s)) {
+    const code = TIFF_CODE[s];
+    return { code, name: CODE_NAMES.get(code) ?? s };
+  }
+  return { code: null, name: s || "unknown" };
+}
+
+/**
+ * Which decoder can read tiles in this compression: `"wasm"` (whitebox-wasm,
+ * the default streaming path), `"geotiff"` (geotiff.js, used for codecs the
+ * wasm decoder lacks such as LERC and ZSTD), or `null` when neither can.
+ */
+export function compressionDecoder(compression) {
+  const s = String(compression ?? "").trim();
+  if (WASM_VARIANTS.has(s)) return "wasm";
+  const { code } = parseCompression(s);
+  if (code !== null && GEOTIFF_CODES.has(code)) return "geotiff";
+  return null;
+}
+
+/** The error message `openCog` rejects with for a codec no decoder handles. */
+export function unsupportedCompressionMessage(compression) {
+  const { code, name } = parseCompression(compression);
+  const label = code === null || !CODE_NAMES.has(code) ? name : `${name} (TIFF compression ${code})`;
+  return `Unsupported compression: ${label}. This COG cannot be decoded in the browser; re-encode it with DEFLATE, ZSTD, LERC, LZW, or WebP.`;
+}

--- a/compression.js
+++ b/compression.js
@@ -23,7 +23,11 @@ const TIFF_CODE = {
 /** Codecs whitebox-wasm's streaming decoder decompresses (by variant name). */
 const WASM_VARIANTS = new Set(["None", "Lzw", "Deflate", "PackBits", "OldJpeg", "Jpeg", "WebP", "JpegXl"]);
 
-/** Codecs geotiff.js decodes (by TIFF code), per its compression registry. */
+/**
+ * Codecs geotiff.js decodes (by TIFF code), per its compression registry. The
+ * whole peer range qualifies: LERC (34887) since 2.0.0 (via `lerc`) and ZSTD
+ * (50000) since 2.1.0 (via `zstddec`), the floor of the declared range.
+ */
 const GEOTIFF_CODES = new Set([1, 5, 6, 7, 8, 32946, 32773, 34887, 50000, 50001]);
 
 /** Human-readable names for TIFF compression codes seen in the wild. */

--- a/compression.js
+++ b/compression.js
@@ -24,11 +24,13 @@ const TIFF_CODE = {
 const WASM_VARIANTS = new Set(["None", "Lzw", "Deflate", "PackBits", "OldJpeg", "Jpeg", "WebP", "JpegXl"]);
 
 /**
- * Codecs geotiff.js decodes (by TIFF code), per its compression registry. The
- * whole peer range qualifies: LERC (34887) since 2.0.0 (via `lerc`) and ZSTD
- * (50000) since 2.1.0 (via `zstddec`), the floor of the declared range.
+ * Codecs geotiff.js decodes (by TIFF code), per its compression registry.
+ * LERC (34887) is registered in every supported geotiff major; direct ZSTD
+ * (50000) only from 3.0.0 (2.x pulls `zstddec` in solely for LERC_ZSTD), so
+ * callers pass `directZstd: false` when the installed geotiff is 2.x.
  */
 const GEOTIFF_CODES = new Set([1, 5, 6, 7, 8, 32946, 32773, 34887, 50000, 50001]);
+const ZSTD_CODE = 50000;
 
 /** Human-readable names for TIFF compression codes seen in the wild. */
 const CODE_NAMES = new Map([
@@ -77,18 +79,24 @@ export function parseCompression(compression) {
  * Which decoder can read tiles in this compression: `"wasm"` (whitebox-wasm,
  * the default streaming path), `"geotiff"` (geotiff.js, used for codecs the
  * wasm decoder lacks such as LERC and ZSTD), or `null` when neither can.
+ * `directZstd` says whether the installed geotiff.js registers TIFF code
+ * 50000 (3.x does, 2.x does not).
  */
-export function compressionDecoder(compression) {
+export function compressionDecoder(compression, { directZstd = true } = {}) {
   const s = String(compression ?? "").trim();
   if (WASM_VARIANTS.has(s)) return "wasm";
   const { code } = parseCompression(s);
+  if (code === ZSTD_CODE && !directZstd) return null;
   if (code !== null && GEOTIFF_CODES.has(code)) return "geotiff";
   return null;
 }
 
 /** The error message `openCog` rejects with for a codec no decoder handles. */
-export function unsupportedCompressionMessage(compression) {
+export function unsupportedCompressionMessage(compression, { directZstd = true } = {}) {
   const { code, name } = parseCompression(compression);
   const label = code === null || !CODE_NAMES.has(code) ? name : `${name} (TIFF compression ${code})`;
+  if (code === ZSTD_CODE && !directZstd) {
+    return `Unsupported compression: ${label}. Decoding ZSTD tiles needs geotiff.js 3.x; this app ships an older geotiff.js.`;
+  }
   return `Unsupported compression: ${label}. This COG cannot be decoded in the browser; re-encode it with DEFLATE, ZSTD, LERC, LZW, or WebP.`;
 }

--- a/lerc-decoder.js
+++ b/lerc-decoder.js
@@ -1,0 +1,141 @@
+// A mask-aware LERC decoder for geotiff.js.
+//
+// geotiff.js decodes LERC tiles (TIFF compression 34887, all three GDAL
+// `LERC` / `LERC_DEFLATE` / `LERC_ZSTD` modes) but discards the LERC validity
+// mask, so every pixel GDAL wrote as nodata comes back as 0 and paints as data.
+// This decoder re-applies the mask: masked pixels become the dataset's
+// GDAL_NODATA value, or NaN for floating-point samples with no declared nodata,
+// which is how the rest of cog-tiler represents "no value". Integer rasters
+// without a declared nodata keep 0 (GDAL does the same on read).
+//
+// The decoder is registered lazily via geotiff's `addDecoder`, replacing the
+// built-in one. It needs the `lerc`, `pako`, and `zstddec` packages that
+// geotiff.js itself depends on; when they cannot be resolved (an unusual
+// install layout) registration is skipped and the built-in decoder stays in
+// place, so LERC still renders, only without the mask.
+
+/** TIFF compression code for LERC. */
+export const LERC_COMPRESSION = 34887;
+
+/** Index into the LercParameters tag (50674). */
+const LERC_ADD_COMPRESSION = 1;
+const ADD_NONE = 0, ADD_DEFLATE = 1, ADD_ZSTD = 2;
+
+/**
+ * The value masked-out LERC pixels are filled with. `nodataTag` is the raw
+ * GDAL_NODATA string (may be undefined); `pixels` the decoded typed array.
+ * Returns `undefined` when no fill can be represented (an integer raster with
+ * no declared nodata, or a nodata outside the type's range).
+ */
+export function lercMaskFillValue(nodataTag, pixels) {
+  const isFloat = pixels instanceof Float32Array || pixels instanceof Float64Array;
+  if (nodataTag != null && String(nodataTag).trim() !== "") {
+    const v = Number(String(nodataTag).trim());
+    if (Number.isNaN(v)) return isFloat ? NaN : undefined;
+    if (!isFloat) {
+      // Typed arrays wrap out-of-range integers silently; only fill when the
+      // declared nodata round-trips through the array's element type.
+      const probe = new pixels.constructor(1);
+      probe[0] = v;
+      if (probe[0] !== v) return undefined;
+    }
+    return v;
+  }
+  return isFloat ? NaN : undefined;
+}
+
+/**
+ * Write `fill` into every masked-out pixel of `pixels` in place. `mask` is
+ * lerc's `Uint8Array(width * height)` (1 = valid) or null when every pixel is
+ * valid; `dims` is the number of interleaved values per pixel.
+ */
+export function applyLercMask(pixels, mask, dims, fill) {
+  if (!mask || fill === undefined) return pixels;
+  const n = mask.length;
+  if (dims <= 1) {
+    for (let i = 0; i < n; i++) if (mask[i] === 0) pixels[i] = fill;
+    return pixels;
+  }
+  for (let i = 0; i < n; i++) {
+    if (mask[i] !== 0) continue;
+    const base = i * dims;
+    for (let d = 0; d < dims; d++) pixels[base + d] = fill;
+  }
+  return pixels;
+}
+
+let registration = null;
+
+/**
+ * Register the mask-aware LERC decoder with geotiff.js (idempotent). Resolves
+ * `true` when registered, `false` when the codec packages could not be loaded
+ * and geotiff's built-in decoder is left in place.
+ */
+export function registerMaskedLercDecoder() {
+  registration ??= (async () => {
+    let geotiff, Lerc, pako, zstddec;
+    try {
+      [geotiff, Lerc, pako, zstddec] = await Promise.all([
+        import("geotiff"),
+        import("lerc"),
+        import("pako"),
+        import("zstddec"),
+      ]);
+    } catch (e) {
+      console.warn("[cog-tiler] LERC mask support unavailable; masked pixels decode as 0:", e);
+      return false;
+    }
+    const { BaseDecoder, addDecoder } = geotiff;
+    if (typeof addDecoder !== "function" || typeof BaseDecoder !== "function") return false;
+    const lerc = Lerc.default ?? Lerc;
+    const inflate = pako.inflate ?? pako.default?.inflate;
+    const ZSTDDecoder = zstddec.ZSTDDecoder ?? zstddec.default?.ZSTDDecoder;
+    if (typeof lerc.decode !== "function" || typeof inflate !== "function" || !ZSTDDecoder) return false;
+    const zstd = new ZSTDDecoder();
+    let ready = null;
+    const init = () => (ready ??= Promise.all([lerc.load?.(), zstd.init()]));
+
+    class MaskedLercDecoder extends BaseDecoder {
+      async decodeBlock(buffer) {
+        await init();
+        const { LercParameters, planarConfiguration, nodata } = this.parameters;
+        const add = LercParameters?.[LERC_ADD_COMPRESSION] ?? ADD_NONE;
+        let bytes = new Uint8Array(buffer);
+        if (add === ADD_DEFLATE) bytes = inflate(bytes);
+        else if (add === ADD_ZSTD) bytes = zstd.decode(bytes);
+        else if (add !== ADD_NONE) {
+          throw new Error(`Unsupported LERC additional compression method identifier: ${add}`);
+        }
+        const result = lerc.decode(bytes, { returnPixelInterleavedDims: planarConfiguration === 1 });
+        const pixels = result.pixels[0];
+        const dims = planarConfiguration === 1 ? Math.max(1, result.dimCount ?? 1) : 1;
+        applyLercMask(pixels, result.mask, dims, lercMaskFillValue(nodata, pixels));
+        return pixels.buffer;
+      }
+    }
+
+    const readTag = async (fd, name) =>
+      fd.hasTag?.(name) === false ? undefined : fd.loadValue ? await fd.loadValue(name) : fd[name];
+    addDecoder(
+      LERC_COMPRESSION,
+      () => Promise.resolve(MaskedLercDecoder),
+      async (fd) => {
+        const tiled = !(await readTag(fd, "StripOffsets"));
+        return {
+          tileWidth: await readTag(fd, tiled ? "TileWidth" : "ImageWidth"),
+          tileHeight: tiled
+            ? await readTag(fd, "TileLength")
+            : (await readTag(fd, "RowsPerStrip")) || (await readTag(fd, "ImageLength")),
+          planarConfiguration: await readTag(fd, "PlanarConfiguration"),
+          bitsPerSample: await readTag(fd, "BitsPerSample"),
+          predictor: (await readTag(fd, "Predictor")) || 1,
+          LercParameters: await readTag(fd, "LercParameters"),
+          nodata: await readTag(fd, "GDAL_NODATA"),
+        };
+      },
+      false, // decode on the main thread: workers would not see this registration
+    );
+    return true;
+  })();
+  return registration;
+}

--- a/lerc-decoder.js
+++ b/lerc-decoder.js
@@ -65,6 +65,25 @@ export function applyLercMask(pixels, mask, dims, fill) {
 }
 
 let registration = null;
+let lercWasmUrl = null;
+
+/**
+ * Tell the decoder where lerc's `lerc-wasm.wasm` is served from. lerc locates
+ * it with `new URL("lerc-wasm.wasm", import.meta.url)`, which bundlers that
+ * hash assets or pre-bundle dependencies do not always rewrite (Vite serves
+ * index.html for the stale path and the wasm compile fails). Hosts can pass
+ * the URL their bundler resolves for the asset, e.g. Vite's
+ * `import lercWasmUrl from "lerc/lerc-wasm.wasm?url"`. Call it before the
+ * first LERC COG is opened; `null` restores lerc's own resolution.
+ */
+export function configureLercDecoder({ wasmUrl } = {}) {
+  lercWasmUrl = wasmUrl == null ? null : String(wasmUrl);
+}
+
+/** The lerc `load()` options for the configured wasm location. */
+export function lercLoadOptions() {
+  return lercWasmUrl ? { locateFile: () => lercWasmUrl } : {};
+}
 
 /**
  * Register the mask-aware LERC decoder with geotiff.js (idempotent). Resolves
@@ -93,7 +112,7 @@ export function registerMaskedLercDecoder() {
     if (typeof lerc.decode !== "function" || typeof inflate !== "function" || !ZSTDDecoder) return false;
     const zstd = new ZSTDDecoder();
     let ready = null;
-    const init = () => (ready ??= Promise.all([lerc.load?.(), zstd.init()]));
+    const init = () => (ready ??= Promise.all([lerc.load?.(lercLoadOptions()), zstd.init()]));
 
     class MaskedLercDecoder extends BaseDecoder {
       async decodeBlock(buffer) {
@@ -109,7 +128,14 @@ export function registerMaskedLercDecoder() {
         const result = lerc.decode(bytes, { returnPixelInterleavedDims: planarConfiguration === 1 });
         const pixels = result.pixels[0];
         const dims = planarConfiguration === 1 ? Math.max(1, result.dimCount ?? 1) : 1;
-        applyLercMask(pixels, result.mask, dims, lercMaskFillValue(nodata, pixels));
+        const fill = lercMaskFillValue(nodata, pixels);
+        if (result.validPixelCount === 0) {
+          // A tile with no valid pixel carries no mask at all; lerc hands back
+          // zeros for it, so fill the whole block rather than trust the mask.
+          if (fill !== undefined) pixels.fill(fill);
+        } else {
+          applyLercMask(pixels, result.mask, dims, fill);
+        }
         return pixels.buffer;
       }
     }

--- a/scripts/prepare-pkg.mjs
+++ b/scripts/prepare-pkg.mjs
@@ -17,6 +17,8 @@ const pkgDir = process.argv[2] || join(root, "crates/cog-tiler-wasm/pkg");
 copyFileSync(join(root, "cog-tiler.js"), join(pkgDir, "cog-tiler.js"));
 copyFileSync(join(root, "sampling.js"), join(pkgDir, "sampling.js"));
 copyFileSync(join(root, "statistics.js"), join(pkgDir, "statistics.js"));
+copyFileSync(join(root, "compression.js"), join(pkgDir, "compression.js"));
+copyFileSync(join(root, "lerc-decoder.js"), join(pkgDir, "lerc-decoder.js"));
 copyFileSync(join(root, "cog-tiler.d.ts"), join(pkgDir, "cog-tiler.d.ts"));
 copyFileSync(join(root, "README.md"), join(pkgDir, "README.md"));
 copyFileSync(join(root, "LICENSE"), join(pkgDir, "LICENSE"));
@@ -40,6 +42,8 @@ pkg.files = Array.from(
     "cog-tiler.js",
     "sampling.js",
     "statistics.js",
+    "compression.js",
+    "lerc-decoder.js",
     "cog-tiler.d.ts",
     "README.md",
     "LICENSE",
@@ -55,6 +59,17 @@ pkg.peerDependencies = {
   proj4: "^2.15.0",
   geotiff: "^2.1.0 || ^3.0.0",
   "geotiff-geokeys-to-proj4": "^2024.4.13 || ^2026.8.16",
+  // Optional: geotiff.js's own LERC codec packages, used by lerc-decoder.js to
+  // re-apply the LERC validity mask. Missing packages degrade to geotiff's
+  // built-in (mask-less) decoder rather than failing.
+  lerc: "^3.0.0 || ^4.0.0",
+  pako: "^1.0.11 || ^2.0.4",
+  zstddec: "^0.2.0",
+};
+pkg.peerDependenciesMeta = {
+  lerc: { optional: true },
+  pako: { optional: true },
+  zstddec: { optional: true },
 };
 pkg.keywords = [
   "cog", "geotiff", "tiler", "webassembly", "wasm",

--- a/tests/compression.test.mjs
+++ b/tests/compression.test.mjs
@@ -1,0 +1,50 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  compressionDecoder,
+  parseCompression,
+  unsupportedCompressionMessage,
+} from '../compression.js';
+
+test('whitebox-decodable variants stay on the wasm path', () => {
+  for (const v of ['None', 'Lzw', 'Deflate', 'PackBits', 'OldJpeg', 'Jpeg', 'WebP', 'JpegXl']) {
+    assert.equal(compressionDecoder(v), 'wasm', v);
+  }
+});
+
+test('LERC and ZSTD (reported as Other(code)) go through geotiff.js', () => {
+  // whitebox-wasm renders unknown codecs with Rust's Debug output, so the
+  // string is literally "Other(34887)" rather than a name.
+  assert.equal(compressionDecoder('Other(34887)'), 'geotiff'); // LERC (all AddCompression modes)
+  assert.equal(compressionDecoder('Other(50000)'), 'geotiff'); // ZSTD
+  assert.equal(compressionDecoder('Other(32946)'), 'geotiff'); // old Deflate code
+});
+
+test('codecs neither decoder handles resolve to null', () => {
+  assert.equal(compressionDecoder('Other(34925)'), null); // LZMA
+  assert.equal(compressionDecoder('Other(34712)'), null); // JPEG 2000
+  assert.equal(compressionDecoder('Huffman'), null); // whitebox names it but cannot decode it
+  assert.equal(compressionDecoder(''), null);
+  assert.equal(compressionDecoder(undefined), null);
+});
+
+test('parseCompression maps names and Other(code) strings to TIFF codes', () => {
+  assert.deepEqual(parseCompression('Jpeg'), { code: 7, name: 'JPEG' });
+  assert.deepEqual(parseCompression('JpegXl'), { code: 50002, name: 'JPEG-XL' });
+  assert.deepEqual(parseCompression('Other(34887)'), { code: 34887, name: 'LERC' });
+  assert.deepEqual(parseCompression('Other(12345)'), { code: 12345, name: 'TIFF compression 12345' });
+  assert.deepEqual(parseCompression('Bogus'), { code: null, name: 'Bogus' });
+});
+
+test('the unsupported message names the codec and its TIFF code', () => {
+  const msg = unsupportedCompressionMessage('Other(34925)');
+  assert.match(msg, /^Unsupported compression: LZMA \(TIFF compression 34925\)\./);
+  assert.match(unsupportedCompressionMessage('Huffman'), /CCITT Huffman \(TIFF compression 2\)/);
+  assert.match(unsupportedCompressionMessage('Bogus'), /^Unsupported compression: Bogus\./);
+  // An unnamed code is not repeated twice in the label.
+  assert.match(unsupportedCompressionMessage('Other(12345)'), /^Unsupported compression: TIFF compression 12345\./);
+  // GDAL >= 3.11 writes JPEG-XL with the final DNG 1.7 code, which whitebox-wasm
+  // does not map yet (it only knows 50002).
+  assert.match(unsupportedCompressionMessage('Other(52546)'), /JPEG-XL \(DNG 1.7 code\) \(TIFF compression 52546\)/);
+});

--- a/tests/compression.test.mjs
+++ b/tests/compression.test.mjs
@@ -48,3 +48,12 @@ test('the unsupported message names the codec and its TIFF code', () => {
   // does not map yet (it only knows 50002).
   assert.match(unsupportedCompressionMessage('Other(52546)'), /JPEG-XL \(DNG 1.7 code\) \(TIFF compression 52546\)/);
 });
+
+test('direct ZSTD is only routed to geotiff.js when the installed major registers it', () => {
+  // geotiff 2.x has zstddec for LERC_ZSTD only; TIFF code 50000 arrived in 3.0.0.
+  assert.equal(compressionDecoder('Other(50000)', { directZstd: false }), null);
+  assert.equal(compressionDecoder('Other(50000)', { directZstd: true }), 'geotiff');
+  assert.equal(compressionDecoder('Other(34887)', { directZstd: false }), 'geotiff'); // LERC unaffected
+  assert.match(unsupportedCompressionMessage('Other(50000)', { directZstd: false }), /needs geotiff\.js 3\.x/);
+  assert.doesNotMatch(unsupportedCompressionMessage('Other(34925)', { directZstd: false }), /geotiff/);
+});

--- a/tests/lerc-decoder.test.mjs
+++ b/tests/lerc-decoder.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { applyLercMask, lercMaskFillValue } from '../lerc-decoder.js';
+
+test('float rasters fill masked pixels with NaN when no nodata is declared', () => {
+  assert.ok(Number.isNaN(lercMaskFillValue(undefined, new Float32Array(1))));
+  assert.ok(Number.isNaN(lercMaskFillValue('', new Float64Array(1))));
+  // GDAL writes NaN nodata as the string "nan".
+  assert.ok(Number.isNaN(lercMaskFillValue('nan', new Float64Array(1))));
+});
+
+test('a declared numeric nodata is used verbatim', () => {
+  assert.equal(lercMaskFillValue('-9999', new Float32Array(1)), -9999);
+  assert.equal(lercMaskFillValue(' 0 ', new Uint8Array(1)), 0);
+  assert.equal(lercMaskFillValue('255', new Uint8Array(1)), 255);
+  assert.equal(lercMaskFillValue('-32768', new Int16Array(1)), -32768);
+});
+
+test('integer rasters without a representable nodata are left alone', () => {
+  assert.equal(lercMaskFillValue(undefined, new Uint8Array(1)), undefined);
+  assert.equal(lercMaskFillValue('nan', new Int16Array(1)), undefined);
+  assert.equal(lercMaskFillValue('-1', new Uint8Array(1)), undefined); // wraps to 255
+  assert.equal(lercMaskFillValue('70000', new Uint16Array(1)), undefined);
+});
+
+test('applyLercMask writes the fill into masked pixels only', () => {
+  const px = Float32Array.from([1, 2, 3, 4]);
+  applyLercMask(px, Uint8Array.from([1, 0, 1, 0]), 1, NaN);
+  assert.equal(px[0], 1);
+  assert.ok(Number.isNaN(px[1]));
+  assert.equal(px[2], 3);
+  assert.ok(Number.isNaN(px[3]));
+});
+
+test('applyLercMask handles pixel-interleaved multi-band blocks', () => {
+  // Two pixels, three bands each; the second pixel is masked.
+  const px = Int16Array.from([10, 20, 30, 40, 50, 60]);
+  applyLercMask(px, Uint8Array.from([1, 0]), 3, -1);
+  assert.deepEqual(Array.from(px), [10, 20, 30, -1, -1, -1]);
+});
+
+test('applyLercMask is a no-op without a mask or a fill value', () => {
+  const px = Float32Array.from([1, 2]);
+  assert.equal(applyLercMask(px, null, 1, NaN), px);
+  assert.deepEqual(Array.from(px), [1, 2]);
+  applyLercMask(px, Uint8Array.from([0, 0]), 1, undefined);
+  assert.deepEqual(Array.from(px), [1, 2]);
+});

--- a/tests/lerc-decoder.test.mjs
+++ b/tests/lerc-decoder.test.mjs
@@ -1,7 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { applyLercMask, lercMaskFillValue } from '../lerc-decoder.js';
+import {
+  applyLercMask,
+  configureLercDecoder,
+  lercLoadOptions,
+  lercMaskFillValue,
+} from '../lerc-decoder.js';
 
 test('float rasters fill masked pixels with NaN when no nodata is declared', () => {
   assert.ok(Number.isNaN(lercMaskFillValue(undefined, new Float32Array(1))));
@@ -46,4 +51,14 @@ test('applyLercMask is a no-op without a mask or a fill value', () => {
   assert.deepEqual(Array.from(px), [1, 2]);
   applyLercMask(px, Uint8Array.from([0, 0]), 1, undefined);
   assert.deepEqual(Array.from(px), [1, 2]);
+});
+
+test('configureLercDecoder routes lerc to the host-provided wasm URL', () => {
+  assert.deepEqual(lercLoadOptions(), {});
+  configureLercDecoder({ wasmUrl: '/assets/lerc-wasm-abc123.wasm' });
+  assert.equal(lercLoadOptions().locateFile('lerc-wasm.wasm', '/wrong/'), '/assets/lerc-wasm-abc123.wasm');
+  configureLercDecoder({ wasmUrl: new URL('https://cdn.example.com/lerc-wasm.wasm') });
+  assert.equal(lercLoadOptions().locateFile(), 'https://cdn.example.com/lerc-wasm.wasm');
+  configureLercDecoder();
+  assert.deepEqual(lercLoadOptions(), {});
 });


### PR DESCRIPTION
## Summary

LERC- and ZSTD-compressed COGs rendered nothing: whitebox-wasm's streaming decoder has no codec for TIFF compression 34887 (LERC, all three `LERC` / `LERC_DEFLATE` / `LERC_ZSTD` modes) or 50000 (ZSTD), so every tile decode threw inside the protocol handler and the map stayed blank with no error. geotiff.js, already a peer for CRS metadata and planar/big-endian reads, decodes both.

- `compression.js` classifies whitebox-wasm's compression string (a variant name, or Rust's Debug output `Other(<code>)` for codecs it does not know) into the decoder that can read it: `wasm`, `geotiff`, or `null`. Exported as `compressionDecoder`, `parseCompression`, `unsupportedCompressionMessage`.
- `openCog` opens the geotiff.js handle for LERC/ZSTD sources, including single-band EPSG:3857 rasters that previously skipped it, and `_assembleWindow` / `point` read through geotiff.js for them, behind a new `readsViaGeoTiff` getter shared with the planar and big-endian cases. (`point()` used the wasm path for big-endian sources before; it now matches `_assembleWindow`.)
- `openCog` rejects at open time, naming the codec and TIFF code, when neither decoder can read the compression (LZMA, JPEG 2000, CCITT, the DNG 1.7 JPEG-XL code 52546, ...). Hosts surface an open failure as a layer error, whereas a tile failure only yields transparent tiles.
- `lerc-decoder.js` registers a mask-aware LERC decoder with geotiff.js. The built-in one discards the LERC validity mask, so GDAL nodata pixels decoded as 0 and painted black. Masked pixels now take `GDAL_NODATA`, or NaN for floating-point rasters without one. It reuses geotiff's own `lerc`, `pako`, and `zstddec` packages (declared as optional peers) and leaves the built-in decoder in place when they cannot be resolved.

Reported in opengeos/GeoLibre#2339.

## Verification

Built COGs from a Float64 EPSG:3857 DEM and a Float32 EPSG:2100 DEM with GDAL 3.12 (`-of COG -co COMPRESS=LERC|LERC_DEFLATE|LERC_ZSTD|ZSTD|DEFLATE|JXL|LZMA`) and loaded each in GeoLibre's Add Data, Raster Layer panel with this build swapped into `node_modules`:

- LERC, LERC_DEFLATE, LERC_ZSTD, ZSTD: render on both the EPSG:3857 fast path and the warp path, nodata transparent, statistics and histogram populated, no console errors.
- DEFLATE control: unchanged.
- LZMA: layer shows "Failed to load: Unsupported compression: LZMA (TIFF compression 34925). ..." instead of a blank map.
- JXL written by GDAL 3.12 uses TIFF code 52546, which whitebox-wasm does not map to its `JpegXl` variant yet (it only knows 50002); it now reports "Unsupported compression: JPEG-XL (DNG 1.7 code) (TIFF compression 52546)" rather than a blank map. Mapping 52546 in whitebox-wasm is a separate follow-up.

`npm test` covers the compression classifier and the mask fill helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading LERC and ZSTD-compressed Cloud Optimized GeoTIFFs.
  * Automatically selects the appropriate decoding method based on the file’s compression.
  * Preserves LERC validity masks, filling masked pixels with the configured no-data value or NaN.
  * Provides clear errors when a file uses an unsupported compression format.

* **Documentation**
  * Added documentation describing supported compression formats and decoding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->